### PR TITLE
Fix ModioRating using an unsigned int to store -1

### DIFF
--- a/include/c/ModioC.h
+++ b/include/c/ModioC.h
@@ -392,7 +392,7 @@ extern "C"
   {
     u32 game_id;
     u32 mod_id;
-    u32 rating;
+    i32 rating;
     u32 date_added;
   };
 


### PR DESCRIPTION
.rating is supposed to be -1 on downvote.
While a comparison of (x.rating == -1) works, albeit with warnings, this will not work:
if (x.rating > 0) { /* upvote */ }
else { /* downvote */ }
which - I think - it should.