### PR TITLE
Alternative to ModioFilterCreator: filter strings

### DIFF
--- a/include/c/ModioC.h
+++ b/include/c/ModioC.h
@@ -509,7 +509,9 @@ extern "C"
   //Events
   void MODIO_DLL modioSetEventListener(void (*callback)(ModioResponse response, ModioModEvent* events_array, u32 events_array_size));
   void MODIO_DLL modioGetEvents(void* object, u32 mod_id, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioModEvent* events_array, u32 events_array_size));
+  void MODIO_DLL modioGetEventsFilterString(void* object, u32 mod_id, char const* filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioModEvent* events_array, u32 events_array_size));
   void MODIO_DLL modioGetAllEvents(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioModEvent* events_array, u32 events_array_size));
+  void MODIO_DLL modioGetAllEventsFilterString(void* object, char const* filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioModEvent* events_array, u32 events_array_size));
 
   //Authentication Methods
   void MODIO_DLL modioEmailRequest(void* object, char const* email, void (*callback)(void* object, ModioResponse response));
@@ -530,6 +532,7 @@ extern "C"
   //Modfile Methods
   void MODIO_DLL modioGetModfile(void* object, u32 mod_id, u32 modfile_id, void (*callback)(void* object, ModioResponse response, ModioModfile modfile));
   void MODIO_DLL modioGetAllModfiles(void* object, u32 mod_id, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioModfile modfiles[], u32 modfiles_size));
+  void MODIO_DLL modioGetAllModfilesFilterString(void* object, u32 mod_id, char const* filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioModfile modfiles[], u32 modfiles_size));
   void MODIO_DLL modioAddModfile(u32 mod_id, ModioModfileCreator modfile_creator);
   void MODIO_DLL modioEditModfile(void* object, u32 mod_id, u32 modfile_id, ModioModfileEditor modfile_handler, void (*callback)(void* object, ModioResponse response, ModioModfile modfile));
   void MODIO_DLL modioDeleteModfile(void* object, u32 mod_id, u32 modfile_id, void (*callback)(void* object, ModioResponse response));
@@ -537,6 +540,7 @@ extern "C"
   //Mods Methods
   void MODIO_DLL modioGetMod(void* object, u32 mod_id, void (*callback)(void* object, ModioResponse response, ModioMod mod));
   void MODIO_DLL modioGetAllMods(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioMod mods[], u32 mods_size));
+  void MODIO_DLL modioGetAllModsFilterString(void* object, char const *filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioMod mods[], u32 mods_size));
   void MODIO_DLL modioAddMod(void* object, ModioModCreator mod_handler, void (*callback)(void* object, ModioResponse response, ModioMod mod));
   void MODIO_DLL modioEditMod(void* object, u32 mod_id, ModioModEditor mod_handler, void (*callback)(void* object, ModioResponse response, ModioMod mod));
   void MODIO_DLL modioDeleteMod(void* object, u32 mod_id, void (*callback)(void* object, ModioResponse response));
@@ -635,11 +639,17 @@ extern "C"
   //Me Methods
   void MODIO_DLL modioGetAuthenticatedUser(void* object, void (*callback)(void* object, ModioResponse response, ModioUser user));
   void MODIO_DLL modioGetUserSubscriptions(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioMod mods[], u32 mods_size));
+  void MODIO_DLL modioGetUserSubscriptionsFilterString(void* object, char const* filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioMod mods[], u32 mods_size));
   void MODIO_DLL modioGetUserEvents(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioUserEvent* events_array, u32 events_array_size));
+  void MODIO_DLL modioGetUserEventsFilterString(void* object, char const* filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioUserEvent* events_array, u32 events_array_size));
   void MODIO_DLL modioGetUserGames(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioGame games[], u32 games_size));
+  void MODIO_DLL modioGetUserGamesFilterString(void* object, char const* filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioGame games[], u32 games_size));
   void MODIO_DLL modioGetUserMods(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioMod mods[], u32 mods_size));
+  void MODIO_DLL modioGetUserModsFilterString(void* object, char const* filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioMod mods[], u32 mods_size));
   void MODIO_DLL modioGetUserModfiles(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioModfile modfiles[], u32 modfiles_size));
+  void MODIO_DLL modioGetUserModfilesFilterString(void* object, char const* filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioModfile modfiles[], u32 modfiles_size));
   void MODIO_DLL modioGetUserRatings(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioRating ratings[], u32 ratings_size));
+  void MODIO_DLL modioGetUserRatingsFilterString(void* object, char const* filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioRating ratings[], u32 ratings_size));
 
   //Settings Methods
   void MODIO_DLL modioInitConfig(void);
@@ -672,6 +682,7 @@ extern "C"
 
   //Comment Methods
   void MODIO_DLL modioGetAllModComments(void* object, u32 mod_id, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioComment comments[], u32 comments_size));
+  void MODIO_DLL modioGetAllModCommentsFilterString(void* object, u32 mod_id, char const* filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioComment comments[], u32 comments_size));
   void MODIO_DLL modioGetModComment(void* object, u32 mod_id, u32 comment_id, void (*callback)(void* object, ModioResponse response, ModioComment comment));  
   void MODIO_DLL modioDeleteModComment(void* object, u32 mod_id, u32 comment_id, void(*callback)(void* object, ModioResponse response));
 
@@ -681,6 +692,7 @@ extern "C"
   //Stats Methods
   void MODIO_DLL modioGetModStats(void* object, u32 mod_id, void (*callback)(void* object, ModioResponse response, ModioStats mod));
   void MODIO_DLL modioGetAllModStats(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioStats mods_stats[], u32 mods_stats_size));
+  void MODIO_DLL modioGetAllModStatsFilterString(void* object, char const* filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioStats mods_stats[], u32 mods_stats_size));
 
   //Free Methods For Schemas Returned By Funtions
   void MODIO_DLL modioFreeInstalledMod(ModioInstalledMod* installed_mod);

--- a/src/c/methods/MeMethods.cpp
+++ b/src/c/methods/MeMethods.cpp
@@ -15,10 +15,9 @@ extern "C"
     modio::curlwrapper::get(call_number, url, modio::getHeaders(), &modioOnGetAuthenticatedUser);
   }
 
-  void modioGetUserSubscriptions(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioMod mods[], u32 mods_size))
+  void modioGetUserSubscriptionsFilterString(void* object, char const* filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioMod mods[], u32 mods_size))
   {
-    std::string filter_string = modio::getFilterString(&filter);
-    std::string url = modio::MODIO_URL + modio::MODIO_VERSION_PATH + "me/subscribed/?" + filter_string + "&api_key=" + modio::API_KEY;
+    std::string url = modio::MODIO_URL + modio::MODIO_VERSION_PATH + "me/subscribed/?" + (filter_string ? filter_string : "") + "&api_key=" + modio::API_KEY;
 
     u32 call_number = modio::curlwrapper::getCallNumber();
 
@@ -28,7 +27,7 @@ extern "C"
     get_user_subscriptions_callbacks[call_number]->url = url;
     get_user_subscriptions_callbacks[call_number]->is_cache = false;
 
-    std::string cache_filename = modio::getCallFileFromCache(url, filter.cache_max_age_seconds);
+    std::string cache_filename = modio::getCallFileFromCache(url, cache_max_age_seconds);
     if(cache_filename != "")
     {
       nlohmann::json cache_file_json = modio::openJson(modio::getModIODirectory() + "cache/" + cache_filename);
@@ -43,11 +42,15 @@ extern "C"
     modio::curlwrapper::get(call_number, url, modio::getHeaders(), &modioOnGetUserSubscriptions);
   }
 
-  void modioGetUserEvents(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioUserEvent* events_array, u32 events_array_size))
+  void modioGetUserSubscriptions(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioMod mods[], u32 mods_size))
   {
     std::string filter_string = modio::getFilterString(&filter);
+    modioGetUserSubscriptionsFilterString(object, filter_string.c_str(), filter.cache_max_age_seconds, callback);
+  }
 
-    std::string url = modio::MODIO_URL + modio::MODIO_VERSION_PATH + "me/events?" + filter_string + "&api_key=" + modio::API_KEY;
+  void modioGetUserEventsFilterString(void* object, char const* filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioUserEvent* events_array, u32 events_array_size))
+  {
+    std::string url = modio::MODIO_URL + modio::MODIO_VERSION_PATH + "me/events?" + (filter_string ? filter_string : "") + "&api_key=" + modio::API_KEY;
 
     u32 call_number = modio::curlwrapper::getCallNumber();
 
@@ -58,10 +61,15 @@ extern "C"
     modio::curlwrapper::get(call_number, url, modio::getHeaders(), &modioOnGetUserEvents);
   }
 
-  void modioGetUserGames(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioGame games[], u32 games_size))
+  void modioGetUserEvents(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioUserEvent* events_array, u32 events_array_size))
   {
     std::string filter_string = modio::getFilterString(&filter);
-    std::string url = modio::MODIO_URL + modio::MODIO_VERSION_PATH + "me/games/?" + filter_string + "&api_key=" + modio::API_KEY;
+    modioGetUserEventsFilterString(object, filter_string.c_str(), filter.cache_max_age_seconds, callback);
+  }
+
+  void modioGetUserGamesFilterString(void* object, char const* filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioGame games[], u32 games_size))
+  {
+    std::string url = modio::MODIO_URL + modio::MODIO_VERSION_PATH + "me/games/?" + (filter_string ? filter_string : "") + "&api_key=" + modio::API_KEY;
 
     u32 call_number = modio::curlwrapper::getCallNumber();
 
@@ -71,7 +79,7 @@ extern "C"
     get_user_games_callbacks[call_number]->url = url;
     get_user_games_callbacks[call_number]->is_cache = false;
 
-    std::string cache_filename = modio::getCallFileFromCache(url, filter.cache_max_age_seconds);
+    std::string cache_filename = modio::getCallFileFromCache(url, cache_max_age_seconds);
     if(cache_filename != "")
     {
       nlohmann::json cache_file_json = modio::openJson(modio::getModIODirectory() + "cache/" + cache_filename);
@@ -86,10 +94,15 @@ extern "C"
     modio::curlwrapper::get(call_number, url, modio::getHeaders(), &modioOnGetUserGames);
   }
 
-  void modioGetUserMods(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioMod mods[], u32 mods_size))
+  void modioGetUserGames(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioGame games[], u32 games_size))
   {
     std::string filter_string = modio::getFilterString(&filter);
-    std::string url = modio::MODIO_URL + modio::MODIO_VERSION_PATH + "me/mods/?" + filter_string + "&api_key=" + modio::API_KEY;
+    modioGetUserGamesFilterString(object, filter_string.c_str(), filter.cache_max_age_seconds, callback);
+  }
+
+  void modioGetUserModsFilterString(void* object, char const* filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioMod mods[], u32 mods_size))
+  {
+    std::string url = modio::MODIO_URL + modio::MODIO_VERSION_PATH + "me/mods/?" + (filter_string ? filter_string : "") + "&api_key=" + modio::API_KEY;
 
     u32 call_number = modio::curlwrapper::getCallNumber();
 
@@ -99,7 +112,7 @@ extern "C"
     get_user_mods_callbacks[call_number]->url = url;
     get_user_mods_callbacks[call_number]->is_cache = false;
 
-    std::string cache_filename = modio::getCallFileFromCache(url, filter.cache_max_age_seconds);
+    std::string cache_filename = modio::getCallFileFromCache(url, cache_max_age_seconds);
     if(cache_filename != "")
     {
       nlohmann::json cache_file_json = modio::openJson(modio::getModIODirectory() + "cache/" + cache_filename);
@@ -114,10 +127,15 @@ extern "C"
     modio::curlwrapper::get(call_number, url, modio::getHeaders(), &modioOnGetUserMods);
   }
 
-  void modioGetUserModfiles(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioModfile modfiles[], u32 modfiles_size))
+  void modioGetUserMods(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioMod mods[], u32 mods_size))
   {
     std::string filter_string = modio::getFilterString(&filter);
-    std::string url = modio::MODIO_URL + modio::MODIO_VERSION_PATH + "me/files/?" + filter_string + "&api_key=" + modio::API_KEY;
+    modioGetUserModsFilterString(object, filter_string.c_str(), filter.cache_max_age_seconds, callback);
+  }
+
+  void modioGetUserModfilesFilterString(void* object, char const* filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioModfile modfiles[], u32 modfiles_size))
+  {
+    std::string url = modio::MODIO_URL + modio::MODIO_VERSION_PATH + "me/files/?" + (filter_string ? filter_string : "") + "&api_key=" + modio::API_KEY;
 
     u32 call_number = modio::curlwrapper::getCallNumber();
 
@@ -127,7 +145,7 @@ extern "C"
     get_user_modfiles_callbacks[call_number]->url = url;
     get_user_modfiles_callbacks[call_number]->is_cache = false;
 
-    std::string cache_filename = modio::getCallFileFromCache(url, filter.cache_max_age_seconds);
+    std::string cache_filename = modio::getCallFileFromCache(url, cache_max_age_seconds);
     if(cache_filename != "")
     {
       nlohmann::json cache_file_json = modio::openJson(modio::getModIODirectory() + "cache/" + cache_filename);
@@ -142,10 +160,15 @@ extern "C"
     modio::curlwrapper::get(call_number, url, modio::getHeaders(), &modioOnGetUserModfiles);
   }
 
-  void modioGetUserRatings(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioRating ratings[], u32 ratings_size))
+  void modioGetUserModfiles(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioModfile modfiles[], u32 modfiles_size))
   {
     std::string filter_string = modio::getFilterString(&filter);
-    std::string url = modio::MODIO_URL + modio::MODIO_VERSION_PATH + "me/ratings/?" + filter_string + "&api_key=" + modio::API_KEY;
+    modioGetUserModfilesFilterString(object, filter_string.c_str(), filter.cache_max_age_seconds, callback);
+  }
+
+  void modioGetUserRatingsFilterString(void* object, char const* filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioRating ratings[], u32 ratings_size))
+  {
+    std::string url = modio::MODIO_URL + modio::MODIO_VERSION_PATH + "me/ratings/?" + (filter_string ? filter_string : "") + "&api_key=" + modio::API_KEY;
 
     u32 call_number = modio::curlwrapper::getCallNumber();
 
@@ -155,7 +178,7 @@ extern "C"
     get_user_ratings_callbacks[call_number]->url = url;
     get_user_ratings_callbacks[call_number]->is_cache = false;
 
-    std::string cache_filename = modio::getCallFileFromCache(url, filter.cache_max_age_seconds);
+    std::string cache_filename = modio::getCallFileFromCache(url, cache_max_age_seconds);
     if(cache_filename != "")
     {
       nlohmann::json cache_file_json = modio::openJson(modio::getModIODirectory() + "cache/" + cache_filename);
@@ -169,4 +192,11 @@ extern "C"
 
     modio::curlwrapper::get(call_number, url, modio::getHeaders(), &modioOnGetUserRatings);
   }
+
+  void modioGetUserRatings(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioRating ratings[], u32 ratings_size))
+  {
+    std::string filter_string = modio::getFilterString(&filter);
+    modioGetUserRatingsFilterString(object, filter_string.c_str(), filter.cache_max_age_seconds, callback);
+  }
+
 }

--- a/src/c/methods/ModEventMethods.cpp
+++ b/src/c/methods/ModEventMethods.cpp
@@ -2,11 +2,9 @@
 
 extern "C"
 {
-  void modioGetEvents(void* object, u32 mod_id, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioModEvent* events_array, u32 events_array_size))
+  void modioGetEventsFilterString(void* object, u32 mod_id, char const* filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioModEvent* events_array, u32 events_array_size))
   {
-    std::string filter_string = modio::getFilterString(&filter);
-
-    std::string url = modio::MODIO_URL + modio::MODIO_VERSION_PATH + "games/" + modio::toString(modio::GAME_ID) + "/mods/" + modio::toString(mod_id) + "/events?" + filter_string + "&api_key=" + modio::API_KEY;
+    std::string url = modio::MODIO_URL + modio::MODIO_VERSION_PATH + "games/" + modio::toString(modio::GAME_ID) + "/mods/" + modio::toString(mod_id) + "/events?" + (filter_string ? filter_string : "") + "&api_key=" + modio::API_KEY;
 
     u32 call_number = modio::curlwrapper::getCallNumber();
 
@@ -17,11 +15,15 @@ extern "C"
     modio::curlwrapper::get(call_number, url, modio::getHeaders(), &modioOnGetEvents);
   }
 
-  void modioGetAllEvents(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioModEvent* events_array, u32 events_array_size))
+  void modioGetEvents(void* object, u32 mod_id, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioModEvent* events_array, u32 events_array_size))
   {
     std::string filter_string = modio::getFilterString(&filter);
+    modioGetEventsFilterString(object, mod_id, filter_string.c_str(), filter.cache_max_age_seconds, callback);
+  }
 
-    std::string url = modio::MODIO_URL + modio::MODIO_VERSION_PATH + "games/" + modio::toString(modio::GAME_ID) + "/mods/events?" + filter_string + "&api_key=" + modio::API_KEY;
+  void modioGetAllEventsFilterString(void* object, char const* filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioModEvent* events_array, u32 events_array_size))
+  {
+    std::string url = modio::MODIO_URL + modio::MODIO_VERSION_PATH + "games/" + modio::toString(modio::GAME_ID) + "/mods/events?" + (filter_string ? filter_string : "") + "&api_key=" + modio::API_KEY;
 
     u32 call_number = modio::curlwrapper::getCallNumber();
 
@@ -30,6 +32,12 @@ extern "C"
     get_all_events_callbacks[call_number]->object = object;
 
     modio::curlwrapper::get(call_number, url, modio::getHeaders(), &modioOnGetAllEvents);
+  }
+
+  void modioGetAllEvents(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioModEvent* events_array, u32 events_array_size))
+  {
+    std::string filter_string = modio::getFilterString(&filter);
+    modioGetAllEventsFilterString(object, filter_string.c_str(), filter.cache_max_age_seconds, callback);
   }
 
   void modioSetEventListener(void (*callback)(ModioResponse response, ModioModEvent* events_array, u32 events_array_size))

--- a/src/c/methods/ModMethods.cpp
+++ b/src/c/methods/ModMethods.cpp
@@ -15,10 +15,9 @@ extern "C"
     modio::curlwrapper::get(call_number, url, modio::getHeaders(), &modioOnGetMod);
   }
 
-  void modioGetAllMods(void *object, ModioFilterCreator filter, void (*callback)(void *object, ModioResponse response, ModioMod mods[], u32 mods_size))
+  void modioGetAllModsFilterString(void* object, char const *filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioMod mods[], u32 mods_size))
   {
-    std::string filter_string = modio::getFilterString(&filter);
-    std::string url = modio::MODIO_URL + modio::MODIO_VERSION_PATH + "games/" + modio::toString(modio::GAME_ID) + "/mods?" + filter_string + "&api_key=" + modio::API_KEY;
+    std::string url = modio::MODIO_URL + modio::MODIO_VERSION_PATH + "games/" + modio::toString(modio::GAME_ID) + "/mods?" + (filter_string ? filter_string : "") + "&api_key=" + modio::API_KEY;
 
     u32 call_number = modio::curlwrapper::getCallNumber();
 
@@ -28,7 +27,7 @@ extern "C"
     get_all_mods_callbacks[call_number]->url = url;
     get_all_mods_callbacks[call_number]->is_cache = false;
 
-    std::string cache_filename = modio::getCallFileFromCache(url, filter.cache_max_age_seconds);
+    std::string cache_filename = modio::getCallFileFromCache(url, cache_max_age_seconds);
     if (cache_filename != "")
     {
       nlohmann::json cache_file_json = modio::openJson(modio::getModIODirectory() + "cache/" + cache_filename);
@@ -42,6 +41,12 @@ extern "C"
     }
 
     modio::curlwrapper::get(call_number, url, modio::getHeaders(), &modioOnGetAllMods);
+  }
+
+  void modioGetAllMods(void *object, ModioFilterCreator filter, void (*callback)(void *object, ModioResponse response, ModioMod mods[], u32 mods_size))
+  {
+    std::string filter_string = modio::getFilterString(&filter);
+    modioGetAllModsFilterString(object, filter_string.c_str(), filter.cache_max_age_seconds, callback);
   }
 
   void modioEditMod(void *object, u32 mod_id, ModioModEditor mod_editor, void (*callback)(void *object, ModioResponse response, ModioMod mod))

--- a/src/c/methods/ModStatsMethods.cpp
+++ b/src/c/methods/ModStatsMethods.cpp
@@ -15,10 +15,9 @@ extern "C"
     modio::curlwrapper::get(call_number, url, modio::getHeaders(), &modioOnGetModStats);
   }
 
-  void modioGetAllModStats(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioStats mods_stats[], u32 mods_stats_size))
+  void modioGetAllModStatsFilterString(void* object, char const* filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioStats mods_stats[], u32 mods_stats_size))
   {
-    std::string filter_string = modio::getFilterString(&filter);
-    std::string url = modio::MODIO_URL + modio::MODIO_VERSION_PATH + "games/" + modio::toString(modio::GAME_ID) + "/mods/stats?" + filter_string + "&api_key=" + modio::API_KEY;
+    std::string url = modio::MODIO_URL + modio::MODIO_VERSION_PATH + "games/" + modio::toString(modio::GAME_ID) + "/mods/stats?" + (filter_string ? filter_string : "") + "&api_key=" + modio::API_KEY;
 
     u32 call_number = modio::curlwrapper::getCallNumber();
 
@@ -28,7 +27,7 @@ extern "C"
     get_all_mod_stats_callbacks[call_number]->url = url;
     get_all_mod_stats_callbacks[call_number]->is_cache = false;
 
-    std::string cache_filename = modio::getCallFileFromCache(url, filter.cache_max_age_seconds);
+    std::string cache_filename = modio::getCallFileFromCache(url, cache_max_age_seconds);
     if(cache_filename != "")
     {
       nlohmann::json cache_file_json = modio::openJson(modio::getModIODirectory() + "cache/" + cache_filename);
@@ -41,5 +40,11 @@ extern "C"
       }
     }
     modio::curlwrapper::get(call_number, url, modio::getHeaders(), &modioOnGetAllModStats);
+  }
+
+  void modioGetAllModStats(void* object, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioStats mods_stats[], u32 mods_stats_size))
+  {
+    std::string filter_string = modio::getFilterString(&filter);
+    modioGetAllModStatsFilterString(object, filter_string.c_str(), filter.cache_max_age_seconds, callback);
   }
 }

--- a/src/c/methods/ModfileMethods.cpp
+++ b/src/c/methods/ModfileMethods.cpp
@@ -15,10 +15,9 @@ extern "C"
     modio::curlwrapper::get(call_number, url, modio::getHeaders(), &modioOnGetModfile);
   }
 
-  void modioGetAllModfiles(void* object, u32 mod_id, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioModfile modfiles[], u32 modfiles_size))
+  void modioGetAllModfilesFilterString(void* object, u32 mod_id, char const* filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioModfile modfiles[], u32 modfiles_size))
   {
-    std::string filter_string = modio::getFilterString(&filter);
-    std::string url = modio::MODIO_URL + modio::MODIO_VERSION_PATH + "games/" + modio::toString(modio::GAME_ID) + "/mods/" + modio::toString(mod_id) + "/files?" + filter_string + "&api_key=" + modio::API_KEY;
+    std::string url = modio::MODIO_URL + modio::MODIO_VERSION_PATH + "games/" + modio::toString(modio::GAME_ID) + "/mods/" + modio::toString(mod_id) + "/files?" + (filter_string ? filter_string : "") + "&api_key=" + modio::API_KEY;
 
     u32 call_number = modio::curlwrapper::getCallNumber();
 
@@ -28,7 +27,7 @@ extern "C"
     get_all_modfiles_callbacks[call_number]->url = url;
     get_all_modfiles_callbacks[call_number]->is_cache = false;
 
-    std::string cache_filename = modio::getCallFileFromCache(url, filter.cache_max_age_seconds);
+    std::string cache_filename = modio::getCallFileFromCache(url, cache_max_age_seconds);
     if(cache_filename != "")
     {
       nlohmann::json cache_file_json = modio::openJson(modio::getModIODirectory() + "cache/" + cache_filename);
@@ -42,6 +41,12 @@ extern "C"
     }
 
     modio::curlwrapper::get(call_number, url, modio::getHeaders(), &modioOnGetAllModfiles);
+  }
+
+  void modioGetAllModfiles(void* object, u32 mod_id, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioModfile modfiles[], u32 modfiles_size))
+  {
+    std::string filter_string = modio::getFilterString(&filter);
+    modioGetAllModfilesFilterString(object, mod_id, filter_string.c_str(), filter.cache_max_age_seconds, callback);
   }
 
   void modioAddModfile(u32 mod_id, ModioModfileCreator modfile_creator)


### PR DESCRIPTION
Bypass ModioFilterCreator to ease filter setup.
Takes the actual query string for the API call underneath.

Adds *FilterString() variants for every function originally
requiring a ModioFilterCreator struct.

e.g. build a query string in script, push it to C and call modioGetAllModsFilterString(), done.
Without this bypass the script generates a query string (or something else) to push the information to C, in C the data is rippped apart to construct ModioFilterCreator, which later concatenates all this data back into a query string. Quite a round-trip..