### PR TITLE
Remove unnecessary 4-byte-sized allocations

### DIFF
--- a/src/c++/methods/AuthenticationInstanceMethods.cpp
+++ b/src/c++/methods/AuthenticationInstanceMethods.cpp
@@ -17,7 +17,7 @@ void Instance::emailRequest(const std::string &email, const std::function<void(c
   struct GenericCall *email_request_call = new GenericCall{callback};
   email_request_calls[current_call_id] = email_request_call;
 
-  modioEmailRequest(new u32(current_call_id), email.c_str(), &onEmailRequest);
+  modioEmailRequest((void*)((uintptr_t)current_call_id), email.c_str(), &onEmailRequest);
 
   current_call_id++;
 }
@@ -27,7 +27,7 @@ void Instance::emailExchange(const std::string &security_code, const std::functi
   struct GenericCall *email_exchange_call = new GenericCall{callback};
   email_exchange_calls[current_call_id] = email_exchange_call;
 
-  modioEmailExchange(new u32(current_call_id), security_code.c_str(), &onEmailExchange);
+  modioEmailExchange((void*)((uintptr_t)current_call_id), security_code.c_str(), &onEmailExchange);
 
   current_call_id++;
 }

--- a/src/c++/methods/CommentsInstanceMethods.cpp
+++ b/src/c++/methods/CommentsInstanceMethods.cpp
@@ -7,7 +7,7 @@ void Instance::getAllModComments(u32 mod_id, modio::FilterCreator &filter, const
     struct GetAllModCommentsCall *get_all_mod_comments_call = new GetAllModCommentsCall{callback};
     get_all_mod_comments_calls[current_call_id] = get_all_mod_comments_call;
 
-    modioGetAllModComments(new u32(current_call_id), mod_id, *filter.getFilter(), &onGetAllModComments);
+    modioGetAllModComments((void*)((uintptr_t)current_call_id), mod_id, *filter.getFilter(), &onGetAllModComments);
 
     current_call_id++;
 }
@@ -17,7 +17,7 @@ void Instance::getModComment(u32 mod_id, u32 comment_id, const std::function<voi
     struct GetModCommentCall *get_mod_comment_call = new GetModCommentCall{callback};
     get_mod_comment_calls[current_call_id] = get_mod_comment_call;
 
-    modioGetModComment(new u32(current_call_id), mod_id, comment_id, &onGetModComment);
+    modioGetModComment((void*)((uintptr_t)current_call_id), mod_id, comment_id, &onGetModComment);
 
     current_call_id++;
 }
@@ -27,7 +27,7 @@ void Instance::deleteModComment(u32 mod_id, u32 comment_id, const std::function<
     struct GenericCall *delete_mod_comment_call = new GenericCall{callback};
     delete_mod_comment_calls[current_call_id] = delete_mod_comment_call;
 
-    modioDeleteModComment(new u32(current_call_id), mod_id, comment_id, &onDeleteModComment);
+    modioDeleteModComment((void*)((uintptr_t)current_call_id), mod_id, comment_id, &onDeleteModComment);
 
     current_call_id++;
 }

--- a/src/c++/methods/DependenciesIntanceMethods.cpp
+++ b/src/c++/methods/DependenciesIntanceMethods.cpp
@@ -7,7 +7,7 @@ void Instance::getAllModDependencies(u32 mod_id, const std::function<void(const 
 	struct GetAllModDependenciesCall *get_all_mod_dependencies_call = new GetAllModDependenciesCall{callback};
 	get_all_mod_dependencies_calls[current_call_id] = get_all_mod_dependencies_call;
 
-	modioGetAllModDependencies(new u32(current_call_id), mod_id, &onGetAllModDependencies);
+	modioGetAllModDependencies((void*)((uintptr_t)current_call_id), mod_id, &onGetAllModDependencies);
 
 	current_call_id++;
 }
@@ -21,7 +21,7 @@ void Instance::addModDependencies(u32 mod_id, std::vector<u32> dependencies, con
 	struct GenericCall *add_mod_dependencies_call = new GenericCall{callback};
 	add_mod_dependencies_calls[current_call_id] = add_mod_dependencies_call;
 
-	modioAddModDependencies(new u32(current_call_id), mod_id, dependencies_array, (u32)dependencies.size(), &onAddModDependencies);
+	modioAddModDependencies((void*)((uintptr_t)current_call_id), mod_id, dependencies_array, (u32)dependencies.size(), &onAddModDependencies);
 	
 	current_call_id++;
 
@@ -37,7 +37,7 @@ void Instance::deleteModDependencies(u32 mod_id, std::vector<u32> dependencies, 
 	struct GenericCall *delete_mod_dependencies_call = new GenericCall{callback};
 	delete_mod_dependencies_calls[current_call_id] = delete_mod_dependencies_call;
 
-	modioDeleteModDependencies(new u32(current_call_id), mod_id, dependencies_array, (u32)dependencies.size(), &onDeleteModDependencies);
+	modioDeleteModDependencies((void*)((uintptr_t)current_call_id), mod_id, dependencies_array, (u32)dependencies.size(), &onDeleteModDependencies);
 	
 	current_call_id++;
 

--- a/src/c++/methods/ExternalAuthenticationInstanceMethods.cpp
+++ b/src/c++/methods/ExternalAuthenticationInstanceMethods.cpp
@@ -8,7 +8,7 @@ void Instance::galaxyAuth(const std::string &appdata, const std::function<void(c
   struct GenericCall *galaxy_auth_call = new GenericCall{callback};
   galaxy_auth_calls[current_call_id] = galaxy_auth_call;
 
-  modioGalaxyAuth(new u32(current_call_id), appdata.c_str(), &onGalaxyAuth);
+  modioGalaxyAuth((void*)((uintptr_t)current_call_id), appdata.c_str(), &onGalaxyAuth);
 
   current_call_id++;
 }
@@ -18,7 +18,7 @@ void Instance::steamAuth(const unsigned char* rgubTicket, u32 cubTicket, const s
   struct GenericCall *steam_auth_call = new GenericCall{callback};
   steam_auth_calls[current_call_id] = steam_auth_call;
 
-  modioSteamAuth(new u32(current_call_id), rgubTicket, cubTicket, &onSteamAuth);
+  modioSteamAuth((void*)((uintptr_t)current_call_id), rgubTicket, cubTicket, &onSteamAuth);
 
   current_call_id++;
 }
@@ -28,7 +28,7 @@ void Instance::steamAuthEncoded(const std::string &base64_ticket, const std::fun
   struct GenericCall *steam_auth_encoded_call = new GenericCall{callback};
   steam_auth_encoded_calls[current_call_id] = steam_auth_encoded_call;
 
-  modioSteamAuthEncoded(new u32(current_call_id), base64_ticket.c_str(), &onSteamAuthEncoded);
+  modioSteamAuthEncoded((void*)((uintptr_t)current_call_id), base64_ticket.c_str(), &onSteamAuthEncoded);
 
   current_call_id++;
 }
@@ -38,7 +38,7 @@ void Instance::linkExternalAccount(u32 service, const std::string &service_id, c
   struct GenericCall *link_external_account_call = new GenericCall{callback};
   link_external_account_calls[current_call_id] = link_external_account_call;
 
-  modioLinkExternalAccount(new u32(current_call_id), service, service_id.c_str(), email.c_str(), &onLinkExternalAccount);
+  modioLinkExternalAccount((void*)((uintptr_t)current_call_id), service, service_id.c_str(), email.c_str(), &onLinkExternalAccount);
 
   current_call_id++;
 }

--- a/src/c++/methods/ImageInstanceMethods.cpp
+++ b/src/c++/methods/ImageInstanceMethods.cpp
@@ -7,7 +7,7 @@ void Instance::downloadImage(const std::string &image_url, const std::string &pa
   struct GenericCall *download_image_call = new GenericCall{callback};
   download_image_calls[current_call_id] = download_image_call;
 
-  modioDownloadImage(new u32(current_call_id), image_url.c_str(), path.c_str(), &onDownloadImage);
+  modioDownloadImage((void*)((uintptr_t)current_call_id), image_url.c_str(), path.c_str(), &onDownloadImage);
 
   current_call_id++;
 }

--- a/src/c++/methods/MeInstanceMethods.cpp
+++ b/src/c++/methods/MeInstanceMethods.cpp
@@ -7,7 +7,7 @@ void Instance::getAuthenticatedUser(const std::function<void(const modio::Respon
   struct GetAuthenticatedUserCall *get_authenticated_user_call = new GetAuthenticatedUserCall{callback};
   get_authenticated_user_calls[current_call_id] = get_authenticated_user_call;
 
-  modioGetAuthenticatedUser(new u32(current_call_id), &onGetAuthenticatedUser);
+  modioGetAuthenticatedUser((void*)((uintptr_t)current_call_id), &onGetAuthenticatedUser);
 
   current_call_id++;
 }
@@ -17,7 +17,7 @@ void Instance::getUserSubscriptions(modio::FilterCreator &filter, const std::fun
   struct GetUserSubscriptionsCall *get_user_subscriptions_call = new GetUserSubscriptionsCall{callback};
   get_user_subscriptions_calls[current_call_id] = get_user_subscriptions_call;
 
-  modioGetUserSubscriptions(new u32(current_call_id), *filter.getFilter(), &onGetUserSubscriptions);
+  modioGetUserSubscriptions((void*)((uintptr_t)current_call_id), *filter.getFilter(), &onGetUserSubscriptions);
 
   current_call_id++;
 }
@@ -27,7 +27,7 @@ void Instance::getUserEvents(modio::FilterCreator &filter, const std::function<v
   struct GetUserEventsCall *get_user_events_call = new GetUserEventsCall{callback};
   get_user_events_calls[current_call_id] = get_user_events_call;
 
-  modioGetUserEvents(new u32(current_call_id), *filter.getFilter(), &onGetUserEvents);
+  modioGetUserEvents((void*)((uintptr_t)current_call_id), *filter.getFilter(), &onGetUserEvents);
 
   current_call_id++;
 }
@@ -37,7 +37,7 @@ void Instance::getUserGames(modio::FilterCreator &filter, const std::function<vo
   struct GetUserGamesCall *get_user_games_call = new GetUserGamesCall{callback};
   get_user_games_calls[current_call_id] = get_user_games_call;
 
-  modioGetUserGames(new u32(current_call_id), *filter.getFilter(), &onGetUserGames);
+  modioGetUserGames((void*)((uintptr_t)current_call_id), *filter.getFilter(), &onGetUserGames);
 
   current_call_id++;
 }
@@ -47,7 +47,7 @@ void Instance::getUserMods(modio::FilterCreator &filter, const std::function<voi
   struct GetUserModsCall *get_user_mods_call = new GetUserModsCall{callback};
   get_user_mods_calls[current_call_id] = get_user_mods_call;
 
-  modioGetUserMods(new u32(current_call_id), *filter.getFilter(), &onGetUserMods);
+  modioGetUserMods((void*)((uintptr_t)current_call_id), *filter.getFilter(), &onGetUserMods);
 
   current_call_id++;
 }
@@ -57,7 +57,7 @@ void Instance::getUserModfiles(modio::FilterCreator &filter, const std::function
   struct GetUserModfilesCall *get_user_modfiles_call = new GetUserModfilesCall{callback};
   get_user_modfiles_calls[current_call_id] = get_user_modfiles_call;
 
-  modioGetUserModfiles(new u32(current_call_id), *filter.getFilter(), &onGetUserModfiles);
+  modioGetUserModfiles((void*)((uintptr_t)current_call_id), *filter.getFilter(), &onGetUserModfiles);
 
   current_call_id++;
 }
@@ -67,7 +67,7 @@ void Instance::getUserRatings(modio::FilterCreator &filter, const std::function<
   struct GetUserRatingsCall *get_user_ratings_call = new GetUserRatingsCall{callback};
   get_user_ratings_calls[current_call_id] = get_user_ratings_call;
 
-  modioGetUserRatings(new u32(current_call_id), *filter.getFilter(), &onGetUserRatings);
+  modioGetUserRatings((void*)((uintptr_t)current_call_id), *filter.getFilter(), &onGetUserRatings);
 
   current_call_id++;
 }

--- a/src/c++/methods/MediaInstanceMethods.cpp
+++ b/src/c++/methods/MediaInstanceMethods.cpp
@@ -7,7 +7,7 @@ void Instance::addModLogo(u32 mod_id, std::string logo_path, const std::function
   struct GenericCall *add_mod_logo_call = new GenericCall{callback};
   add_mod_logo_calls[current_call_id] = add_mod_logo_call;
 
-  modioAddModLogo(new u32(current_call_id), mod_id, logo_path.c_str(), &onAddModLogo);
+  modioAddModLogo((void*)((uintptr_t)current_call_id), mod_id, logo_path.c_str(), &onAddModLogo);
 
   current_call_id++;
 }
@@ -24,7 +24,7 @@ void Instance::addModImages(u32 mod_id, std::vector<std::string> image_paths, co
   struct GenericCall *add_mod_images_call = new GenericCall{callback};
   add_mod_images_calls[current_call_id] = add_mod_images_call;
 
-  modioAddModImages(new u32(current_call_id), mod_id, image_paths_array, (u32)image_paths.size(), &onAddModImages);
+  modioAddModImages((void*)((uintptr_t)current_call_id), mod_id, image_paths_array, (u32)image_paths.size(), &onAddModImages);
 
   current_call_id++;
 
@@ -45,7 +45,7 @@ void Instance::addModYoutubeLinks(u32 mod_id, std::vector<std::string> youtube_l
   struct GenericCall *add_mod_youtube_links_call = new GenericCall{callback};
   add_mod_youtube_links_calls[current_call_id] = add_mod_youtube_links_call;
 
-  modioAddModYoutubeLinks(new u32(current_call_id), mod_id, youtube_links_array, (u32)youtube_links.size(), &onAddModYoutubeLinks);
+  modioAddModYoutubeLinks((void*)((uintptr_t)current_call_id), mod_id, youtube_links_array, (u32)youtube_links.size(), &onAddModYoutubeLinks);
 
   current_call_id++;
 
@@ -66,7 +66,7 @@ void Instance::addModSketchfabLinks(u32 mod_id, std::vector<std::string> sketchf
   struct GenericCall *add_mod_sketchfab_links_call = new GenericCall{callback};
   add_mod_sketchfab_links_calls[current_call_id] = add_mod_sketchfab_links_call;
 
-  modioAddModSketchfabLinks(new u32(current_call_id), mod_id, sketchfab_links_array, (u32)sketchfab_links.size(), &onAddModSketchfabLinks);
+  modioAddModSketchfabLinks((void*)((uintptr_t)current_call_id), mod_id, sketchfab_links_array, (u32)sketchfab_links.size(), &onAddModSketchfabLinks);
 
   for (size_t i = 0; i < sketchfab_links.size(); i++)
     delete[] sketchfab_links_array[i];
@@ -87,7 +87,7 @@ void Instance::deleteModImages(u32 mod_id, std::vector<std::string> image_paths,
   struct GenericCall *delete_mod_images_call = new GenericCall{callback};
   delete_mod_images_calls[current_call_id] = delete_mod_images_call;
 
-  modioDeleteModImages(new u32(current_call_id), mod_id, image_paths_array, (u32)image_paths.size(), &onDeleteModImages);
+  modioDeleteModImages((void*)((uintptr_t)current_call_id), mod_id, image_paths_array, (u32)image_paths.size(), &onDeleteModImages);
 
   current_call_id++;
 
@@ -108,7 +108,7 @@ void Instance::deleteModYoutubeLinks(u32 mod_id, std::vector<std::string> youtub
   struct GenericCall *delete_mod_youtube_links_call = new GenericCall{callback};
   delete_mod_youtube_links_calls[current_call_id] = delete_mod_youtube_links_call;
 
-  modioDeleteModYoutubeLinks(new u32(current_call_id), mod_id, youtube_links_array, (u32)youtube_links.size(), &onDeleteModYoutubeLinks);
+  modioDeleteModYoutubeLinks((void*)((uintptr_t)current_call_id), mod_id, youtube_links_array, (u32)youtube_links.size(), &onDeleteModYoutubeLinks);
 
   current_call_id++;
 
@@ -129,7 +129,7 @@ void Instance::deleteModSketchfabLinks(u32 mod_id, std::vector<std::string> sket
   struct GenericCall *delete_mod_sketchfab_links_call = new GenericCall{callback};
   delete_mod_sketchfab_links_calls[current_call_id] = delete_mod_sketchfab_links_call;
 
-  modioDeleteModSketchfabLinks(new u32(current_call_id), mod_id, sketchfab_links_array, (u32)sketchfab_links.size(), &onDeleteModSketchfabLinks);
+  modioDeleteModSketchfabLinks((void*)((uintptr_t)current_call_id), mod_id, sketchfab_links_array, (u32)sketchfab_links.size(), &onDeleteModSketchfabLinks);
 
   current_call_id++;
 

--- a/src/c++/methods/MetadataKVPInstanceMethods.cpp
+++ b/src/c++/methods/MetadataKVPInstanceMethods.cpp
@@ -7,7 +7,7 @@ namespace modio
     struct GetAllMetadataKVPCall* get_all_metadata_kvp_call = new GetAllMetadataKVPCall{callback};
     get_all_metadata_kvp_calls[current_call_id] = get_all_metadata_kvp_call;
 
-    modioGetAllMetadataKVP(new u32(current_call_id), mod_id, &onGetAllMetadataKVP);
+    modioGetAllMetadataKVP((void*)((uintptr_t)current_call_id), mod_id, &onGetAllMetadataKVP);
 
     current_call_id++;
   }
@@ -27,7 +27,7 @@ namespace modio
     struct GenericCall* add_metadata_kvp_call = new GenericCall{callback};
     add_metadata_kvp_calls[current_call_id] = add_metadata_kvp_call;
 
-    modioAddMetadataKVP(new u32(current_call_id), mod_id, metadata_kvp_array, (u32)metadata_kvp.size(), &onAddMetadataKVP);
+    modioAddMetadataKVP((void*)((uintptr_t)current_call_id), mod_id, metadata_kvp_array, (u32)metadata_kvp.size(), &onAddMetadataKVP);
     
     current_call_id++;
 
@@ -51,7 +51,7 @@ namespace modio
     struct GenericCall* delete_metadata_kvp_call = new GenericCall{callback};
     delete_metadata_kvp_calls[current_call_id] = delete_metadata_kvp_call;
 
-    modioDeleteMetadataKVP(new u32(current_call_id), mod_id, metadata_kvp_array, (u32)metadata_kvp.size(), &onDeleteMetadataKVP);
+    modioDeleteMetadataKVP((void*)((uintptr_t)current_call_id), mod_id, metadata_kvp_array, (u32)metadata_kvp.size(), &onDeleteMetadataKVP);
 
     current_call_id++;
 

--- a/src/c++/methods/ModEventInstanceMethods.cpp
+++ b/src/c++/methods/ModEventInstanceMethods.cpp
@@ -7,7 +7,7 @@ void Instance::getEvents(u32 mod_id, modio::FilterCreator &filter, const std::fu
   struct GetEventsCall *get_events_call = new GetEventsCall{callback};
   get_events_calls[current_call_id] = get_events_call;
 
-  modioGetEvents(new u32(current_call_id), mod_id, *filter.getFilter(), &onGetEvents);
+  modioGetEvents((void*)((uintptr_t)current_call_id), mod_id, *filter.getFilter(), &onGetEvents);
 
   current_call_id++;
 }
@@ -17,7 +17,7 @@ void Instance::getAllEvents(modio::FilterCreator &filter, const std::function<vo
   struct GetAllEventsCall *get_all_events_call = new GetAllEventsCall{callback};
   get_all_events_calls[current_call_id] = get_all_events_call;
 
-  modioGetAllEvents(new u32(current_call_id), *filter.getFilter(), &onGetAllEvents);
+  modioGetAllEvents((void*)((uintptr_t)current_call_id), *filter.getFilter(), &onGetAllEvents);
 
   current_call_id++;
 }

--- a/src/c++/methods/ModInstanceMethods.cpp
+++ b/src/c++/methods/ModInstanceMethods.cpp
@@ -7,7 +7,7 @@ void Instance::getMod(u32 mod_id, const std::function<void(const modio::Response
   struct GetModCall *get_mod_call = new GetModCall{callback};
   get_mod_calls[current_call_id] = get_mod_call;
 
-  modioGetMod(new u32(current_call_id), mod_id, &onGetMod);
+  modioGetMod((void*)((uintptr_t)current_call_id), mod_id, &onGetMod);
 
   current_call_id++;
 }
@@ -17,7 +17,7 @@ void Instance::getAllMods(modio::FilterCreator &filter, const std::function<void
   struct GetAllModsCall *get_mods_call = new GetAllModsCall{callback};
   get_all_mods_calls[current_call_id] = get_mods_call;
 
-  modioGetAllMods(new u32(current_call_id), *filter.getFilter(), &onGetAllMods);
+  modioGetAllMods((void*)((uintptr_t)current_call_id), *filter.getFilter(), &onGetAllMods);
 
   current_call_id++;
 }
@@ -27,7 +27,7 @@ void Instance::addMod(modio::ModCreator &mod_handler, const std::function<void(c
   struct AddModCall *add_mod_call = new AddModCall{callback};
   add_mod_calls[current_call_id] = add_mod_call;
 
-  modioAddMod(new u32(current_call_id), *mod_handler.getModioModCreator(), &onAddMod);
+  modioAddMod((void*)((uintptr_t)current_call_id), *mod_handler.getModioModCreator(), &onAddMod);
 
   current_call_id++;
 }
@@ -37,7 +37,7 @@ void Instance::editMod(u32 mod_id, modio::ModEditor &mod_handler, const std::fun
   struct EditModCall *edit_mod_call = new EditModCall{callback};
   edit_mod_calls[current_call_id] = edit_mod_call;
 
-  modioEditMod(new u32(current_call_id), mod_id, *mod_handler.getModioModEditor(), &onEditMod);
+  modioEditMod((void*)((uintptr_t)current_call_id), mod_id, *mod_handler.getModioModEditor(), &onEditMod);
 
   current_call_id++;
 }
@@ -47,7 +47,7 @@ void Instance::deleteMod(u32 mod_id, const std::function<void(const modio::Respo
   struct GenericCall *delete_mod_call = new GenericCall{callback};
   delete_mod_calls[current_call_id] = delete_mod_call;
 
-  modioDeleteMod(new u32(current_call_id), mod_id, &onDeleteMod);
+  modioDeleteMod((void*)((uintptr_t)current_call_id), mod_id, &onDeleteMod);
 
   current_call_id++;
 }

--- a/src/c++/methods/ModStatsInstanceMethods.cpp
+++ b/src/c++/methods/ModStatsInstanceMethods.cpp
@@ -7,7 +7,7 @@ void Instance::getModStats(u32 mod_id, const std::function<void(const modio::Res
   struct GetModStatsCall *get_mod_stats_call = new GetModStatsCall{callback};
   get_mod_stats_calls[current_call_id] = get_mod_stats_call;
 
-  modioGetModStats(new u32(current_call_id), mod_id, &onGetModStats);
+  modioGetModStats((void*)((uintptr_t)current_call_id), mod_id, &onGetModStats);
 
   current_call_id++;
 }
@@ -17,7 +17,7 @@ void Instance::getAllModStats(modio::FilterCreator &filter, const std::function<
   struct GetAllModStatsCall *get_all_mod_stats_call = new GetAllModStatsCall{callback};
   get_all_mod_stats_calls[current_call_id] = get_all_mod_stats_call;
 
-  modioGetAllModStats(new u32(current_call_id), *filter.getFilter(), &onGetAllModStats);
+  modioGetAllModStats((void*)((uintptr_t)current_call_id), *filter.getFilter(), &onGetAllModStats);
 
   current_call_id++;
 }

--- a/src/c++/methods/ModfileInstanceMethods.cpp
+++ b/src/c++/methods/ModfileInstanceMethods.cpp
@@ -7,7 +7,7 @@ void Instance::getModfile(u32 mod_id, u32 modfile_id, const std::function<void(c
   struct GetModfileCall *get_modfile_call = new GetModfileCall{callback};
   get_modfile_calls[current_call_id] = get_modfile_call;
 
-  modioGetModfile(new u32(current_call_id), mod_id, modfile_id, &onGetModfile);
+  modioGetModfile((void*)((uintptr_t)current_call_id), mod_id, modfile_id, &onGetModfile);
 
   current_call_id++;
 }
@@ -17,7 +17,7 @@ void Instance::getAllModfiles(u32 mod_id, modio::FilterCreator &filter, const st
   struct GetAllModfilesCall *get_all_modfiles_call = new GetAllModfilesCall{callback};
   get_all_modfiles_calls[current_call_id] = get_all_modfiles_call;
 
-  modioGetAllModfiles(new u32(current_call_id), mod_id, *filter.getFilter(), &onGetAllModfiles);
+  modioGetAllModfiles((void*)((uintptr_t)current_call_id), mod_id, *filter.getFilter(), &onGetAllModfiles);
 
   current_call_id++;
 }
@@ -32,7 +32,7 @@ void Instance::editModfile(u32 mod_id, u32 modfile_id, modio::ModfileEditor &mod
   struct EditModfileCall *edit_modfile_call = new EditModfileCall{callback};
   edit_modfile_calls[current_call_id] = edit_modfile_call;
 
-  modioEditModfile(new u32(current_call_id), mod_id, modfile_id, *modfile_handler.getModioModfileEditor(), &onEditModfile);
+  modioEditModfile((void*)((uintptr_t)current_call_id), mod_id, modfile_id, *modfile_handler.getModioModfileEditor(), &onEditModfile);
 
   current_call_id++;
 }
@@ -42,7 +42,7 @@ void Instance::deleteModfile(u32 mod_id, u32 modfile_id, const std::function<voi
   struct GenericCall *delete_modfile_call = new GenericCall{callback};
   delete_modfile_calls[current_call_id] = delete_modfile_call;
 
-  modioDeleteModfile(new u32(current_call_id), mod_id, modfile_id, &onDeleteModfile);
+  modioDeleteModfile((void*)((uintptr_t)current_call_id), mod_id, modfile_id, &onDeleteModfile);
 
   current_call_id++;
 }

--- a/src/c++/methods/RatingsInstanceMethods.cpp
+++ b/src/c++/methods/RatingsInstanceMethods.cpp
@@ -7,7 +7,7 @@ void Instance::addModRating(u32 mod_id, bool vote_up, const std::function<void(c
   struct GenericCall *add_mod_rating_call = new GenericCall{callback};
   add_mod_rating_calls[current_call_id] = add_mod_rating_call;
 
-  modioAddModRating(new u32(current_call_id), mod_id, vote_up, &onAddModRating);
+  modioAddModRating((void*)((uintptr_t)current_call_id), mod_id, vote_up, &onAddModRating);
 
   current_call_id++;
 }

--- a/src/c++/methods/ReportsInstanceMethods.cpp
+++ b/src/c++/methods/ReportsInstanceMethods.cpp
@@ -7,7 +7,7 @@ namespace modio
 		struct GenericCall* submit_report_call = new GenericCall{ callback };
 		submit_report_calls[current_call_id] = submit_report_call;
 
-		modioSubmitReport(new u32(current_call_id), resource.c_str(), id, type, name.c_str(), summary.c_str(), &onSubmitReport);
+		modioSubmitReport((void*)((uintptr_t)current_call_id), resource.c_str(), id, type, name.c_str(), summary.c_str(), &onSubmitReport);
 
 		current_call_id++;
 	}

--- a/src/c++/methods/SubscribeInstanceMethods.cpp
+++ b/src/c++/methods/SubscribeInstanceMethods.cpp
@@ -7,7 +7,7 @@ void Instance::subscribeToMod(u32 mod_id, const std::function<void(const modio::
   struct SubscribeToModCall *subscribe_to_mod_call = new SubscribeToModCall{callback};
   subscribe_to_mod_calls[current_call_id] = subscribe_to_mod_call;
 
-  modioSubscribeToMod(new u32(current_call_id), mod_id, &onSubscribeToMod);
+  modioSubscribeToMod((void*)((uintptr_t)current_call_id), mod_id, &onSubscribeToMod);
 
   current_call_id++;
 }
@@ -17,7 +17,7 @@ void Instance::unsubscribeFromMod(u32 mod_id, const std::function<void(const mod
   struct GenericCall *unsubscribe_from_mod_call = new GenericCall{callback};
   unsubscribe_from_mod_calls[current_call_id] = unsubscribe_from_mod_call;
 
-  modioUnsubscribeFromMod(new u32(current_call_id), mod_id, &onUnsubscribeFromMod);
+  modioUnsubscribeFromMod((void*)((uintptr_t)current_call_id), mod_id, &onUnsubscribeFromMod);
 
   current_call_id++;
 }

--- a/src/c++/methods/TagsInstanceMethods.cpp
+++ b/src/c++/methods/TagsInstanceMethods.cpp
@@ -7,7 +7,7 @@ void Instance::getModTags(u32 mod_id, const std::function<void(const modio::Resp
   struct GetModTagsCall *get_mod_tags_call = new GetModTagsCall{callback};
   get_mod_tags_calls[current_call_id] = get_mod_tags_call;
 
-  modioGetModTags(new u32(current_call_id), mod_id, &onGetModTags);
+  modioGetModTags((void*)((uintptr_t)current_call_id), mod_id, &onGetModTags);
 
   current_call_id++;
 }
@@ -24,7 +24,7 @@ void Instance::addModTags(u32 mod_id, std::vector<std::string> tags, const std::
   struct GenericCall *add_mod_tags_call = new GenericCall{callback};
   add_mod_tags_calls[current_call_id] = add_mod_tags_call;
 
-  modioAddModTags(new u32(current_call_id), mod_id, tags_array, (u32)tags.size(), &onAddModTags);
+  modioAddModTags((void*)((uintptr_t)current_call_id), mod_id, tags_array, (u32)tags.size(), &onAddModTags);
 
   current_call_id++;
 
@@ -45,7 +45,7 @@ void Instance::deleteModTags(u32 mod_id, std::vector<std::string> tags, const st
   struct GenericCall *delete_mod_tags_call = new GenericCall{callback};
   delete_mod_tags_calls[current_call_id] = delete_mod_tags_call;
 
-  modioDeleteModTags(new u32(current_call_id), mod_id, tags_array, (u32)tags.size(), &onDeleteModTags);
+  modioDeleteModTags((void*)((uintptr_t)current_call_id), mod_id, tags_array, (u32)tags.size(), &onDeleteModTags);
 
   current_call_id++;
 

--- a/src/c++/methods/callbacks/AuthenticationInstanceCallbacks.cpp
+++ b/src/c++/methods/callbacks/AuthenticationInstanceCallbacks.cpp
@@ -7,7 +7,7 @@ std::map<u32, GenericCall *> email_exchange_calls;
 
 void onEmailRequest(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
 
@@ -15,21 +15,19 @@ void onEmailRequest(void *object, ModioResponse modio_response)
 
   email_request_calls[call_id]->callback(response);
 
-  delete (u32 *)object;
   delete email_request_calls[call_id];
   email_request_calls.erase(call_id);
 }
 
 void onEmailExchange(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
 
   email_exchange_calls[call_id]->callback(response);
 
-  delete (u32 *)object;
   delete email_exchange_calls[call_id];
   email_exchange_calls.erase(call_id);
 }

--- a/src/c++/methods/callbacks/CommentsInstanceCallbacks.cpp
+++ b/src/c++/methods/callbacks/CommentsInstanceCallbacks.cpp
@@ -8,7 +8,7 @@ std::map<u32, GenericCall *> delete_mod_comment_calls;
 
 void onGetAllModComments(void *object, ModioResponse modio_response, ModioComment *comments_array, u32 comments_array_size)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -22,14 +22,13 @@ void onGetAllModComments(void *object, ModioResponse modio_response, ModioCommen
 
   get_all_mod_comments_calls[call_id]->callback(response, comments_vector);
 
-  delete (u32 *)object;
   delete get_all_mod_comments_calls[call_id];
   get_all_mod_comments_calls.erase(call_id);
 }
 
 void onGetModComment(void *object, ModioResponse modio_response, ModioComment modio_comment)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -43,21 +42,19 @@ void onGetModComment(void *object, ModioResponse modio_response, ModioComment mo
 
   get_mod_comment_calls[call_id]->callback(response, comment);
 
-  delete (u32 *)object;
   delete get_mod_comment_calls[call_id];
   get_mod_comment_calls.erase(call_id);
 }
 
 void onDeleteModComment(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
 
   delete_mod_comment_calls[call_id]->callback(response);
 
-  delete (u32 *)object;
   delete delete_mod_comment_calls[call_id];
   delete_mod_comment_calls.erase(call_id);
 }

--- a/src/c++/methods/callbacks/DependenciesIntanceCallbaks.cpp
+++ b/src/c++/methods/callbacks/DependenciesIntanceCallbaks.cpp
@@ -8,7 +8,7 @@ std::map<u32, GenericCall *> delete_mod_dependencies_calls;
 
 void onGetAllModDependencies(void *object, ModioResponse modio_response, ModioDependency *dependencies_array, u32 dependencies_array_size)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -22,35 +22,32 @@ void onGetAllModDependencies(void *object, ModioResponse modio_response, ModioDe
 
   get_all_mod_dependencies_calls[call_id]->callback(response, dependencies_vector);
 
-  delete (u32 *)object;
   delete get_all_mod_dependencies_calls[call_id];
   get_all_mod_dependencies_calls.erase(call_id);
 }
 
 void onAddModDependencies(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
 
   add_mod_dependencies_calls[call_id]->callback(response);
 
-  delete (u32 *)object;
   delete add_mod_dependencies_calls[call_id];
   add_mod_dependencies_calls.erase(call_id);
 }
 
 void onDeleteModDependencies(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
 
   delete_mod_dependencies_calls[call_id]->callback(response);
 
-  delete (u32 *)object;
   delete delete_mod_dependencies_calls[call_id];
   delete_mod_dependencies_calls.erase(call_id);
 }

--- a/src/c++/methods/callbacks/ExternalAuthenticationInstanceCallbacks.cpp
+++ b/src/c++/methods/callbacks/ExternalAuthenticationInstanceCallbacks.cpp
@@ -9,7 +9,7 @@ std::map<u32, GenericCall *> link_external_account_calls;
 
 void onGalaxyAuth(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
 
@@ -17,14 +17,13 @@ void onGalaxyAuth(void *object, ModioResponse modio_response)
 
   galaxy_auth_calls[call_id]->callback(response);
 
-  delete (u32 *)object;
   delete galaxy_auth_calls[call_id];
   galaxy_auth_calls.erase(call_id);
 }
 
 void onSteamAuth(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
 
@@ -32,14 +31,13 @@ void onSteamAuth(void *object, ModioResponse modio_response)
 
   steam_auth_calls[call_id]->callback(response);
 
-  delete (u32 *)object;
   delete steam_auth_calls[call_id];
   steam_auth_calls.erase(call_id);
 }
 
 void onSteamAuthEncoded(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
 
@@ -47,14 +45,13 @@ void onSteamAuthEncoded(void *object, ModioResponse modio_response)
 
   steam_auth_encoded_calls[call_id]->callback(response);
 
-  delete (u32 *)object;
   delete steam_auth_encoded_calls[call_id];
   steam_auth_encoded_calls.erase(call_id);
 }
 
 void onLinkExternalAccount(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
 
@@ -62,7 +59,6 @@ void onLinkExternalAccount(void *object, ModioResponse modio_response)
 
   link_external_account_calls[call_id]->callback(response);
 
-  delete (u32 *)object;
   delete link_external_account_calls[call_id];
   link_external_account_calls.erase(call_id);
 }

--- a/src/c++/methods/callbacks/ImageInstanceCallbacks.cpp
+++ b/src/c++/methods/callbacks/ImageInstanceCallbacks.cpp
@@ -6,14 +6,13 @@ std::map<u32, GenericCall *> download_image_calls;
 
 void onDownloadImage(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
 
   download_image_calls[call_id]->callback(response);
 
-  delete (u32 *)object;
   delete download_image_calls[call_id];
   download_image_calls.erase(call_id);
 }

--- a/src/c++/methods/callbacks/MeInstanceCallbacks.cpp
+++ b/src/c++/methods/callbacks/MeInstanceCallbacks.cpp
@@ -12,7 +12,7 @@ std::map<u32, GetUserRatingsCall *> get_user_ratings_calls;
 
 void onGetAuthenticatedUser(void *object, ModioResponse modio_response, ModioUser modio_user)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -26,14 +26,13 @@ void onGetAuthenticatedUser(void *object, ModioResponse modio_response, ModioUse
 
   get_authenticated_user_calls[call_id]->callback(response, user);
 
-  delete (u32 *)object;
   delete get_authenticated_user_calls[call_id];
   get_authenticated_user_calls.erase(call_id);
 }
 
 void onGetUserSubscriptions(void *object, ModioResponse modio_response, ModioMod mods[], u32 mods_size)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -47,14 +46,13 @@ void onGetUserSubscriptions(void *object, ModioResponse modio_response, ModioMod
 
   get_user_subscriptions_calls[call_id]->callback(response, mods_vector);
 
-  delete (u32 *)object;
   delete get_user_subscriptions_calls[call_id];
   get_user_subscriptions_calls.erase(call_id);
 }
 
 void onGetUserEvents(void *object, ModioResponse modio_response, ModioUserEvent *events_array, u32 events_array_size)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -68,13 +66,12 @@ void onGetUserEvents(void *object, ModioResponse modio_response, ModioUserEvent 
   get_user_events_calls[call_id]->callback(response, event_vector);
 
   delete get_user_events_calls[call_id];
-  delete (u32 *)object;
   get_user_events_calls.erase(call_id);
 }
 
 void onGetUserGames(void *object, ModioResponse modio_response, ModioGame games[], u32 games_size)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -88,14 +85,13 @@ void onGetUserGames(void *object, ModioResponse modio_response, ModioGame games[
 
   get_user_games_calls[call_id]->callback(response, games_vector);
 
-  delete (u32 *)object;
   delete get_user_games_calls[call_id];
   get_user_games_calls.erase(call_id);
 }
 
 void onGetUserMods(void *object, ModioResponse modio_response, ModioMod mods[], u32 mods_size)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -109,14 +105,13 @@ void onGetUserMods(void *object, ModioResponse modio_response, ModioMod mods[], 
 
   get_user_mods_calls[call_id]->callback(response, mods_vector);
 
-  delete (u32 *)object;
   delete get_user_mods_calls[call_id];
   get_user_mods_calls.erase(call_id);
 }
 
 void onGetUserModfiles(void *object, ModioResponse modio_response, ModioModfile modfiles[], u32 modfiles_size)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -130,14 +125,13 @@ void onGetUserModfiles(void *object, ModioResponse modio_response, ModioModfile 
 
   get_user_modfiles_calls[call_id]->callback(response, modfiles_vector);
 
-  delete (u32 *)object;
   delete get_user_modfiles_calls[call_id];
   get_user_modfiles_calls.erase(call_id);
 }
 
 void onGetUserRatings(void *object, ModioResponse modio_response, ModioRating ratings[], u32 ratings_size)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -151,7 +145,6 @@ void onGetUserRatings(void *object, ModioResponse modio_response, ModioRating ra
 
   get_user_ratings_calls[call_id]->callback(response, ratings_vector);
 
-  delete (u32 *)object;
   delete get_user_ratings_calls[call_id];
   get_user_ratings_calls.erase(call_id);
 }

--- a/src/c++/methods/callbacks/MediaInstanceCallbacks.cpp
+++ b/src/c++/methods/callbacks/MediaInstanceCallbacks.cpp
@@ -12,98 +12,91 @@ std::map<u32, GenericCall *> delete_mod_sketchfab_links_calls;
 
 void onAddModLogo(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
 
   add_mod_logo_calls[call_id]->callback(response);
 
-  delete (u32 *)object;
   delete add_mod_logo_calls[call_id];
   add_mod_logo_calls.erase(call_id);
 }
 
 void onAddModImages(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
 
   add_mod_images_calls[call_id]->callback(response);
 
-  delete (u32 *)object;
   delete add_mod_images_calls[call_id];
   add_mod_images_calls.erase(call_id);
 }
 
 void onAddModYoutubeLinks(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
 
   add_mod_youtube_links_calls[call_id]->callback(response);
 
-  delete (u32 *)object;
   delete add_mod_youtube_links_calls[call_id];
   add_mod_youtube_links_calls.erase(call_id);
 }
 
 void onAddModSketchfabLinks(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
 
   add_mod_sketchfab_links_calls[call_id]->callback(response);
 
-  delete (u32 *)object;
   delete add_mod_sketchfab_links_calls[call_id];
   add_mod_sketchfab_links_calls.erase(call_id);
 }
 
 void onDeleteModImages(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
 
   delete_mod_images_calls[call_id]->callback(response);
 
-  delete (u32 *)object;
   delete delete_mod_images_calls[call_id];
   delete_mod_images_calls.erase(call_id);
 }
 
 void onDeleteModYoutubeLinks(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
 
   delete_mod_youtube_links_calls[call_id]->callback(response);
 
-  delete (u32 *)object;
   delete delete_mod_youtube_links_calls[call_id];
   delete_mod_youtube_links_calls.erase(call_id);
 }
 
 void onDeleteModSketchfabLinks(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
 
   delete_mod_sketchfab_links_calls[call_id]->callback(response);
 
-  delete (u32 *)object;
   delete delete_mod_sketchfab_links_calls[call_id];
   delete_mod_sketchfab_links_calls.erase(call_id);
 }

--- a/src/c++/methods/callbacks/MetadataKVPInstanceCallbacks.cpp
+++ b/src/c++/methods/callbacks/MetadataKVPInstanceCallbacks.cpp
@@ -8,7 +8,7 @@ std::map<u32, GenericCall *> delete_metadata_kvp_calls;
 
 void onGetAllMetadataKVP(void *object, ModioResponse modio_response, ModioMetadataKVP *metadata_kvp_array, u32 metadata_kvp_array_size)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -22,33 +22,30 @@ void onGetAllMetadataKVP(void *object, ModioResponse modio_response, ModioMetada
   get_all_metadata_kvp_calls[call_id]->callback(response, metadata_kvp_vector);
 
   delete get_all_metadata_kvp_calls[call_id];
-  delete (u32 *)object;
   get_all_metadata_kvp_calls.erase(call_id);
 }
 
 void onAddMetadataKVP(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
 
   add_metadata_kvp_calls[call_id]->callback(response);
   delete add_metadata_kvp_calls[call_id];
-  delete (u32 *)object;
   add_metadata_kvp_calls.erase(call_id);
 }
 
 void onDeleteMetadataKVP(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
 
   delete_metadata_kvp_calls[call_id]->callback(response);
   delete delete_metadata_kvp_calls[call_id];
-  delete (u32 *)object;
   delete_metadata_kvp_calls.erase(call_id);
 }
 

--- a/src/c++/methods/callbacks/ModEventsInstanceCallbacks.cpp
+++ b/src/c++/methods/callbacks/ModEventsInstanceCallbacks.cpp
@@ -8,7 +8,7 @@ SetEventListenerCall *set_event_listener_call;
 
 void onGetEvents(void *object, ModioResponse modio_response, ModioModEvent *events_array, u32 events_array_size)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -22,13 +22,12 @@ void onGetEvents(void *object, ModioResponse modio_response, ModioModEvent *even
   get_events_calls[call_id]->callback(response, event_vector);
 
   delete get_events_calls[call_id];
-  delete (u32 *)object;
   get_events_calls.erase(call_id);
 }
 
 void onGetAllEvents(void *object, ModioResponse modio_response, ModioModEvent *events_array, u32 events_array_size)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -42,7 +41,6 @@ void onGetAllEvents(void *object, ModioResponse modio_response, ModioModEvent *e
   get_all_events_calls[call_id]->callback(response, event_vector);
 
   delete get_all_events_calls[call_id];
-  delete (u32 *)object;
   get_all_events_calls.erase(call_id);
 }
 

--- a/src/c++/methods/callbacks/ModInstanceCallbacks.cpp
+++ b/src/c++/methods/callbacks/ModInstanceCallbacks.cpp
@@ -10,7 +10,7 @@ std::map<u32, GenericCall *> delete_mod_calls;
 
 void onGetMod(void *object, ModioResponse modio_response, ModioMod mod)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -24,14 +24,13 @@ void onGetMod(void *object, ModioResponse modio_response, ModioMod mod)
 
   get_mod_calls[call_id]->callback(response, modio_mod);
 
-  delete (u32 *)object;
   delete get_mod_calls[call_id];
   get_mod_calls.erase(call_id);
 }
 
 void onGetAllMods(void *object, ModioResponse modio_response, ModioMod mods[], u32 mods_size)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -45,14 +44,13 @@ void onGetAllMods(void *object, ModioResponse modio_response, ModioMod mods[], u
 
   get_all_mods_calls[call_id]->callback(response, mods_vector);
 
-  delete (u32 *)object;
   delete get_all_mods_calls[call_id];
   get_all_mods_calls.erase(call_id);
 }
 
 void onAddMod(void *object, ModioResponse modio_response, ModioMod mod)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -66,14 +64,13 @@ void onAddMod(void *object, ModioResponse modio_response, ModioMod mod)
 
   add_mod_calls[call_id]->callback(response, modio_mod);
 
-  delete (u32 *)object;
   delete add_mod_calls[call_id];
   add_mod_calls.erase(call_id);
 }
 
 void onEditMod(void *object, ModioResponse modio_response, ModioMod mod)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -81,21 +78,19 @@ void onEditMod(void *object, ModioResponse modio_response, ModioMod mod)
   modio::Mod modio_mod;
   edit_mod_calls[call_id]->callback(response, modio_mod);
 
-  delete (u32 *)object;
   delete edit_mod_calls[call_id];
   edit_mod_calls.erase(call_id);
 }
 
 void onDeleteMod(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
 
   delete_mod_calls[call_id]->callback(response);
 
-  delete (u32 *)object;
   delete delete_mod_calls[call_id];
   delete_mod_calls.erase(call_id);
 }

--- a/src/c++/methods/callbacks/ModStatsInstanceCallbacks.cpp
+++ b/src/c++/methods/callbacks/ModStatsInstanceCallbacks.cpp
@@ -7,7 +7,7 @@ std::map<u32, GetAllModStatsCall *> get_all_mod_stats_calls;
 
 void onGetModStats(void *object, ModioResponse modio_response, ModioStats modio_stats)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -21,14 +21,13 @@ void onGetModStats(void *object, ModioResponse modio_response, ModioStats modio_
 
   get_mod_stats_calls[call_id]->callback(response, stats);
 
-  delete (u32 *)object;
   delete get_mod_stats_calls[call_id];
   get_mod_stats_calls.erase(call_id);
 }
 
 void onGetAllModStats(void *object, ModioResponse modio_response, ModioStats modio_mods_stats[], u32 modio_mods_stats_size)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -42,7 +41,6 @@ void onGetAllModStats(void *object, ModioResponse modio_response, ModioStats mod
 
   get_all_mod_stats_calls[call_id]->callback(response, mod_stats_vector);
 
-  delete (u32 *)object;
   delete get_all_mod_stats_calls[call_id];
   get_all_mod_stats_calls.erase(call_id);
 }

--- a/src/c++/methods/callbacks/ModfileInstanceCallbacks.cpp
+++ b/src/c++/methods/callbacks/ModfileInstanceCallbacks.cpp
@@ -10,7 +10,7 @@ std::map<u32, GenericCall *> delete_modfile_calls;
 
 void onGetModfile(void *object, ModioResponse modio_response, ModioModfile modfile)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -23,14 +23,13 @@ void onGetModfile(void *object, ModioResponse modio_response, ModioModfile modfi
 
   get_modfile_calls[call_id]->callback(response, modio_modfile);
 
-  delete (u32 *)object;
   delete get_modfile_calls[call_id];
   get_modfile_calls.erase(call_id);
 }
 
 void onGetAllModfiles(void *object, ModioResponse modio_response, ModioModfile modfiles[], u32 modfiles_size)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -44,14 +43,13 @@ void onGetAllModfiles(void *object, ModioResponse modio_response, ModioModfile m
 
   get_all_modfiles_calls[call_id]->callback(response, modfiles_vector);
 
-  delete (u32 *)object;
   delete get_all_modfiles_calls[call_id];
   get_all_modfiles_calls.erase(call_id);
 }
 
 void onAddModfile(void *object, ModioResponse modio_response, ModioModfile modio_modfile)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -61,14 +59,13 @@ void onAddModfile(void *object, ModioResponse modio_response, ModioModfile modio
 
   add_modfile_calls[call_id]->callback(response, modfile);
 
-  delete (u32 *)object;
   delete add_modfile_calls[call_id];
   add_modfile_calls.erase(call_id);
 }
 
 void onEditModfile(void *object, ModioResponse modio_response, ModioModfile modio_modfile)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -77,20 +74,18 @@ void onEditModfile(void *object, ModioResponse modio_response, ModioModfile modi
   modfile.initialize(modio_modfile);
 
   edit_modfile_calls[call_id]->callback(response, modfile);
-  delete (u32 *)object;
   delete edit_modfile_calls[call_id];
   edit_modfile_calls.erase(call_id);
 }
 
 void onDeleteModfile(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
 
   delete_modfile_calls[call_id]->callback(response);
-  delete (u32 *)object;
   delete delete_modfile_calls[call_id];
   delete_modfile_calls.erase(call_id);
 }

--- a/src/c++/methods/callbacks/RatingsInstanceCallbacks.cpp
+++ b/src/c++/methods/callbacks/RatingsInstanceCallbacks.cpp
@@ -6,14 +6,13 @@ std::map<u32, GenericCall *> add_mod_rating_calls;
 
 void onAddModRating(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
 
   add_mod_rating_calls[call_id]->callback(response);
 
-  delete (u32 *)object;
   delete add_mod_rating_calls[call_id];
   add_mod_rating_calls.erase(call_id);
 }

--- a/src/c++/methods/callbacks/ReportsInstanceCallbacks.cpp
+++ b/src/c++/methods/callbacks/ReportsInstanceCallbacks.cpp
@@ -6,14 +6,13 @@ std::map<u32, GenericCall *> submit_report_calls;
 
 void onSubmitReport(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
 
   submit_report_calls[call_id]->callback(response);
 
-  delete (u32 *)object;
   delete submit_report_calls[call_id];
   submit_report_calls.erase(call_id);
 }

--- a/src/c++/methods/callbacks/SubscriptionInstanceCallbacks.cpp
+++ b/src/c++/methods/callbacks/SubscriptionInstanceCallbacks.cpp
@@ -7,7 +7,7 @@ std::map<u32, GenericCall *> unsubscribe_from_mod_calls;
 
 void onSubscribeToMod(void *object, ModioResponse modio_response, ModioMod mod)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -21,21 +21,19 @@ void onSubscribeToMod(void *object, ModioResponse modio_response, ModioMod mod)
 
   subscribe_to_mod_calls[call_id]->callback(response, modio_mod);
 
-  delete (u32 *)object;
   delete subscribe_to_mod_calls[call_id];
   subscribe_to_mod_calls.erase(call_id);
 }
 
 void onUnsubscribeFromMod(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
 
   unsubscribe_from_mod_calls[call_id]->callback(response);
 
-  delete (u32 *)object;
   delete unsubscribe_from_mod_calls[call_id];
   unsubscribe_from_mod_calls.erase(call_id);
 }

--- a/src/c++/methods/callbacks/TagsInstanceCallbacks.cpp
+++ b/src/c++/methods/callbacks/TagsInstanceCallbacks.cpp
@@ -8,7 +8,7 @@ std::map<u32, GenericCall *> delete_mod_tags_calls;
 
 void onGetModTags(void *object, ModioResponse modio_response, ModioTag *tags_array, u32 tags_array_size)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
@@ -22,33 +22,30 @@ void onGetModTags(void *object, ModioResponse modio_response, ModioTag *tags_arr
   get_mod_tags_calls[call_id]->callback(response, tags_vector);
 
   delete get_mod_tags_calls[call_id];
-  delete (u32 *)object;
   get_mod_tags_calls.erase(call_id);
 }
 
 void onAddModTags(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
 
   add_mod_tags_calls[call_id]->callback(response);
   delete add_mod_tags_calls[call_id];
-  delete (u32 *)object;
   add_mod_tags_calls.erase(call_id);
 }
 
 void onDeleteModTags(void *object, ModioResponse modio_response)
 {
-  u32 call_id = *((u32 *)object);
+  u32 call_id = (u32)((uintptr_t)object);
 
   modio::Response response;
   response.initialize(modio_response);
 
   delete_mod_tags_calls[call_id]->callback(response);
   delete delete_mod_tags_calls[call_id];
-  delete (u32 *)object;
   delete_mod_tags_calls.erase(call_id);
 }
 


### PR DESCRIPTION
No need for heap allocations if the data fits in the pointer itself.