### PR TITLE
Replace mode=static with CMake's BUILD_SHARED_LIBS flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ script:
   - make -j2
   - make test
   - if [[ "$TRAVIS_TAG" ]]; then
-      cmake -D mode=static . ;
-      make -j2 ; 
+      cmake -D BUILD_SHARED_LIBS=OFF . ;
+      make -j2 ;
     fi
   - if [ "$TRAVIS_TAG" ]; then
       if [ "$TRAVIS_OS_NAME" == "osx" ]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,9 @@ project(modio)
 set(CMAKE_BUILD_TYPE Release)
 set (CMAKE_CXX_STANDARD 11)
 
-# set the mode flag as static to compile statically, for example:
-# cmake -D mode=static .
+# set BUILD_SHARED_LIBs to OFF to compile statically, for example:
+# cmake -D BUILD_SHARED_LIBS=OFF .
+option(BUILD_SHARED_LIBS "Build Shared Libraries" ON)
 
 # MSVC: set the crtmode flag to 'static' to include the Visual C++
 # runtime statically. Requires libcurl to be built with /MT as well.
@@ -14,15 +15,14 @@ include_directories(include additional_dependencies include/dependencies/miniz)
 
 file(GLOB_RECURSE SOURCES "src/*.cpp" "src/*.c")
 
-if( mode AND mode STREQUAL "static" )
+add_library(modio ${SOURCES})
+if( BUILD_SHARED_LIBS )
+  message("Building mod.io SDK dynamically")
+  add_definitions(-DMODIO_DYNAMICLIB -DCURL_STATICLIB)
+else()
   message("Building mod.io SDK statically")
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
   add_definitions(-DMODIO_STATICLIB -DCURL_STATICLIB)
-  add_library(modio STATIC ${SOURCES})
-else()
-  message("Building mod.io SDK dynamically")
-  add_definitions(-DMODIO_DYNAMICLIB -DCURL_STATICLIB)
-  add_library(modio SHARED ${SOURCES})
 endif()
 
 IF (APPLE)

--- a/appveyor_build_config.bat
+++ b/appveyor_build_config.bat
@@ -1,6 +1,6 @@
 mkdir test_build
 cd test_build
-cmake -D mode=static -D test=on -D gtest_force_shared_crt=on -G "Visual Studio 15" c:\projects\source
+cmake -D BUILD_SHARED_LIBS=OFF -D test=on -D gtest_force_shared_crt=on -G "Visual Studio 15" c:\projects\source
 cmake --build . --config "Debug"
 cd ..
 
@@ -16,11 +16,11 @@ if %APPVEYOR_REPO_TAG% == true (
   cmake --build . --config "Release"
   mkdir ..\static_x86
   cd ..\static_x86
-  cmake -D mode=static -G "Visual Studio 15" c:\projects\source
+  cmake -D BUILD_SHARED_LIBS=OFF -G "Visual Studio 15" c:\projects\source
   cmake --build . --config "Release"
   mkdir ..\static_x64
   cd ..\static_x64
-  cmake -D mode=static -G "Visual Studio 15 Win64" c:\projects\source
+  cmake -D BUILD_SHARED_LIBS=OFF -G "Visual Studio 15 Win64" c:\projects\source
   cmake --build . --config "Release"
   cd ..
   7z a Windows.zip dynamic_x86\Release\* dynamic_x64\Release\* static_x86\Release\* static_x64\Release\*


### PR DESCRIPTION
CMake already has a flag for controlling static/shared builds, so let's use that instead: https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html

Also made it an option so it's exposed to the CMake GUI and customizable by users.