### PR TITLE
Don't override CMAKE_BUILD_TYPE setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.5)
 project(modio)
-set(CMAKE_BUILD_TYPE Release)
 set (CMAKE_CXX_STANDARD 11)
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
 
 # set the mode flag as static to compile statically, for example:
 # cmake -D mode=static .


### PR DESCRIPTION
Explicitly setting CMAKE_BUILD_TYPE overrides any option the user might set. Instead let's check if it's set first, effectively making it a default.

While Release is a nice default for production, we still wanna be able to build other configurations so we can use Debug builds with Debug programs (in C++ all libs and programs must have the same configuration or nasty crashes will happen).