### PR TITLE
GitHub Actions for CI and release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,102 @@
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+
+    strategy:
+      fail-fast: true
+      matrix:
+        name:
+          - Ubuntu 16.04 GCC
+          - Ubuntu 16.04 Clang
+          - Ubuntu 18.04 GCC
+          - Ubuntu 18.04 Clang
+          - Windows 2019 MSVC
+          # - Windows 2019 GCC
+          - macOS 10.14 GCC
+          - macOS 10.14 Clang
+        include:
+          - name: Ubuntu 16.04 GCC
+            os: ubuntu-16.04
+            compiler: gcc
+            cpp-compiler: g++
+
+          - name: Ubuntu 16.04 Clang
+            os: ubuntu-16.04
+            compiler: clang
+            cpp-compiler: clang++
+            packages: llvm-3.5
+
+          - name: Ubuntu 18.04 GCC
+            os: ubuntu-18.04
+            compiler: gcc
+            cpp-compiler: g++
+
+          - name: Ubuntu 18.04 Clang
+            os: ubuntu-18.04
+            compiler: clang
+            cpp-compiler: clang++
+            packages: llvm-3.9
+
+          - name: Windows 2019 MSVC
+            os: windows-2019
+            compiler: cl
+            cmake-args: -DBUILD_SHARED_LIBS=OFF -Dgtest_force_shared_crt=on
+
+          # - name: Windows 2019 GCC
+          #   os: windows-2019
+          #   compiler: gcc
+          #   cmake-args: -G Ninja
+          #   packages: ninja
+
+          - name: macOS 10.14 GCC
+            os: macOS-10.14
+            compiler: gcc
+            cpp-compiler: g++
+
+          - name: macOS 10.14 Clang
+            os: macOS-10.14
+            compiler: clang
+            cpp-compiler: clang++
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Install packages (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install libcurl4-gnutls-dev ${{ matrix.packages }}
+
+      - name: Install packages (Windows)
+        if: runner.os == 'Windows' && matrix.packages
+        run: |
+          choco install ${{ matrix.packages }}
+
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Generate project files
+        run: |
+          mkdir ${{ matrix.build-dir || '.not-used' }}
+          cd ${{ matrix.build-dir || '.' }}
+          cmake ${{ matrix.build-src-dir || '.' }} -Dtest=on ${{ matrix.cmake-args }}
+        env:
+          CC: ${{ matrix.compiler }}
+          CXX: ${{ matrix.cpp-compiler }}
+          CFLAGS: ${{ matrix.cflags || env.CFLAGS }}
+          CXXFLAGS: ${{ matrix.cxxflags || env.CXXFLAGS }}
+          LDFLAGS: ${{ matrix.ldflags || env.LDFLAGS }}
+
+      - name: Compile source code
+        run: |
+          cd ${{ matrix.build-src-dir || '.' }}
+          cmake --build . --config ${{ matrix.build-config || 'Release' }}
+
+      - name: Run test cases
+        run: |
+          cd ${{ matrix.build-dir || '.' }}
+          ctest -C ${{ matrix.build-config || 'Release' }} --output-on-failure

--- a/.github/workflows/convert-docs.sh
+++ b/.github/workflows/convert-docs.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+WIKI_DIR=$1
+EXPORT_DIR=$2
+TOKEN=$3
+
+for file in $WIKI_DIR/*.md; do
+    filename=$(basename "$file" .md)
+    grip "$file" --no-inline --export $EXPORT_DIR/"$filename.html" --pass=$TOKEN
+
+    for file2 in $WIKI_DIR/*.md; do
+        filename2=$(basename "$file2" .md)
+
+        filename_with_spaces=${filename2//-/ }
+
+        expression="s/\[\[$filename_with_spaces]]/<a href='$filename2.html'>$filename_with_spaces<\/a>/g"
+
+        sed -i -e "$expression" $EXPORT_DIR/"$filename.html"
+    done
+done

--- a/.github/workflows/readme.txt
+++ b/.github/workflows/readme.txt
@@ -1,0 +1,10 @@
+Mod.io SDK
+==========
+
+Welcome to mod.io SDK, built using C++. It allows game developers to host and
+automatically install user-created mods in their games. It connects to
+the mod.io API, the documentation for its endpoints can be viewed here:
+https://docs.mod.io
+
+SDK repository and documentation can be viewed here:
+https://sdk.mod.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,9 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v1
+
+      - name: Checkout wiki
+        uses: actions/checkout@v1
         with:
           repository: modio/SDK.wiki
           ref: master
@@ -120,18 +123,7 @@ jobs:
           mkdir -p docs
           rename.ul '::' '__' ../SDK.wiki/*
 
-          for file in ../SDK.wiki/*.md; do
-            filename=$(basename "$file" .md)
-            grip "$file" --no-inline --export docs/"$filename.html" --pass=${{ secrets.GITHUB_TOKEN }}
-
-            for file2 in ../SDK.wiki/*.md; do
-              filename2=$(basename "$file2" .md)
-
-              filename_with_spaces=${filename2//-/ }
-
-              sed -i -e "s/\[\[$filename_with_spaces]]/<a href='$filename2.html'>$filename_with_spaces<\/a>/g" docs/"$filename.html"
-            done
-          done
+          ./.github/workflows/convert-docs.sh ../SDK.wiki ./docs ${{ secrets.GITHUB_TOKEN }}
 
           zip docs.zip docs/*
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,7 +233,7 @@ jobs:
           mv additional_dependencies "$package"
           mv include "$package"
           mv LICENSE "$package/License.txt"
-          touch "$package/Readme.txt"
+          cp .github/workflows/readme.txt "$package/Readme.txt"
 
           zip -r "$package.zip" "$package"/*
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,268 @@
+name: release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+
+    strategy:
+      matrix:
+        name:
+          - Ubuntu 18.04 GCC+libcurl-gnutls
+          - Ubuntu 18.04 GCC+libcurl-gnutls +static
+          - Windows 2019 MSVC win32
+          - Windows 2019 MSVC win32 +static
+          - Windows 2019 MSVC win64
+          - Windows 2019 MSVC win64 +static
+          - macOS 10.14 Clang
+          - macOS 10.14 Clang +static
+        include:
+          - name: Ubuntu 18.04 GCC+libcurl-gnutls
+            os: ubuntu-18.04
+            artifact-name: x86_64-linux-gnu
+
+          - name: Ubuntu 18.04 GCC+libcurl-gnutls +static
+            os: ubuntu-18.04
+            cmake-args: -DBUILD_SHARED_LIBS=OFF
+            artifact-name: x86_64-linux-gnu+static
+
+          - name: Windows 2019 MSVC win32
+            os: windows-2019
+            cmake-args: -A Win32
+            artifact-name: i686-windows-msvc
+
+          - name: Windows 2019 MSVC win32 +static
+            os: windows-2019
+            cmake-args: -A Win32 -DBUILD_SHARED_LIBS=OFF
+            artifact-name: i686-windows-msvc+static
+
+          - name: Windows 2019 MSVC win64
+            os: windows-2019
+            cmake-args: -A x64
+            artifact-name: x86_64-windows-msvc
+
+          - name: Windows 2019 MSVC win64 +static
+            os: windows-2019
+            cmake-args: -A x64 -DBUILD_SHARED_LIBS=OFF
+            artifact-name: x86_64-windows-msvc+static
+
+          - name: macOS 10.14 Clang
+            os: macOS-10.14
+            artifact-name: x86_64-apple-darwin
+
+          - name: macOS 10.14 Clang +static
+            os: macOS-10.14
+            cmake-args: -DBUILD_SHARED_LIBS=OFF
+            artifact-name: x86_64-apple-darwin+static
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Install packages (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install libcurl4-gnutls-dev
+
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Generate project files
+        run: |
+          mkdir ${{ matrix.build-dir || '.not-used' }}
+          cd ${{ matrix.build-dir || '.' }}
+          cmake ${{ matrix.build-src-dir || '.' }} ${{ matrix.cmake-args }}
+        env:
+          CC: ${{ matrix.compiler }}
+          CFLAGS: ${{ matrix.cflags }}
+          LDFLAGS: ${{ matrix.ldflags }}
+
+      - name: Compile source code
+        run: |
+          cd ${{ matrix.build-src-dir || '.' }}
+          cmake --build . --config ${{ matrix.build-config || 'Release' }}
+
+      - name: Prepare artifact
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        shell: bash
+        run: |
+          mkdir Release
+          mv libmodio* Release
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: Release
+
+  docs:
+    name: Generate docs.zip
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install packages
+        run: |
+          sudo apt-get install python3-pip
+          sudo pip install grip
+
+      - name: Checkout
+        uses: actions/checkout@v1
+        with:
+          repository: modio/SDK.wiki
+          ref: master
+
+      - name: Build
+        run: |
+          mkdir -p docs
+          rename.ul '::' '__' ../SDK.wiki/*
+
+          for file in ../SDK.wiki/*.md; do
+            filename=$(basename "$file" .md)
+            grip "$file" --no-inline --export docs/"$filename.html" --pass=${{ secrets.GITHUB_TOKEN }}
+
+            for file2 in ../SDK.wiki/*.md; do
+              filename2=$(basename "$file2" .md)
+
+              filename_with_spaces=${filename2//-/ }
+
+              sed -i -e "s/\[\[$filename_with_spaces]]/<a href='$filename2.html'>$filename_with_spaces<\/a>/g" docs/"$filename.html"
+            done
+          done
+
+          zip docs.zip docs/*
+
+      - name: Upload
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_name: docs.zip
+          asset_path: docs.zip
+          asset_content_type: application/zip
+
+  sdk:
+    name: Generate mod.io-sdk.zip
+    needs: build
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Download Linux
+        uses: actions/download-artifact@v1
+        with:
+          name: x86_64-linux-gnu
+          path: artifacts/x86_64-linux-gnu
+
+      - name: Download Linux +static
+        uses: actions/download-artifact@v1
+        with:
+          name: x86_64-linux-gnu+static
+          path: artifacts/x86_64-linux-gnu+static
+
+      - name: Download Win32
+        uses: actions/download-artifact@v1
+        with:
+          name: i686-windows-msvc
+          path: artifacts/i686-windows-msvc
+
+      - name: Download Win32 +static
+        uses: actions/download-artifact@v1
+        with:
+          name: i686-windows-msvc+static
+          path: artifacts/i686-windows-msvc+static
+
+      - name: Download Win64
+        uses: actions/download-artifact@v1
+        with:
+          name: x86_64-windows-msvc
+          path: artifacts/x86_64-windows-msvc
+
+      - name: Download Win64 +static
+        uses: actions/download-artifact@v1
+        with:
+          name: x86_64-windows-msvc+static
+          path: artifacts/x86_64-windows-msvc+static
+
+      - name: Download macOS
+        uses: actions/download-artifact@v1
+        with:
+          name: x86_64-apple-darwin
+          path: artifacts/x86_64-apple-darwin
+
+      - name: Download macOS +static
+        uses: actions/download-artifact@v1
+        with:
+          name: x86_64-apple-darwin+static
+          path: artifacts/x86_64-apple-darwin+static
+
+      - name: Build
+        id: build
+        run: |
+          tag=$(git describe --tags --abbrev=0)
+          package="mod.io-sdk-$tag"
+
+          # linux
+          mkdir -p "$package"/{lib,static}/linux/x64
+          mv artifacts/x86_64-linux-gnu/libmodio.so "$package/lib/linux/x64"
+          mv artifacts/x86_64-linux-gnu+static/libmodio.a "$package/static/linux/x64"
+
+          # win32 & win64
+          mkdir -p "$package"/{bin,lib,static}/msvc/{x86,x64}
+
+          mv artifacts/i686-windows-msvc/modio.dll "$package/bin/msvc/x86"
+          mv artifacts/i686-windows-msvc/modio.lib "$package/lib/msvc/x86"
+          mv artifacts/i686-windows-msvc+static/modio.lib "$package/static/msvc/x86"
+
+          mv artifacts/x86_64-windows-msvc/modio.dll "$package/bin/msvc/x64"
+          mv artifacts/x86_64-windows-msvc/modio.lib "$package/lib/msvc/x64"
+          mv artifacts/x86_64-windows-msvc+static/modio.lib "$package/static/msvc/x64"
+
+          # macOS
+          mkdir -p "$package"/{lib,static}/macOS/x64
+          mv artifacts/x86_64-apple-darwin/libmodio.dylib "$package/lib/macOS/x64"
+          mv artifacts/x86_64-apple-darwin+static/libmodio.a "$package/static/macOS/x64"
+
+          mv additional_dependencies "$package"
+          mv include "$package"
+          mv LICENSE "$package/License.txt"
+          touch "$package/Readme.txt"
+
+          zip -r "$package.zip" "$package"/*
+
+          echo "::set-output name=asset_name::$package.zip"
+          echo "::set-output name=asset_path::$package.zip"
+
+      - name: Checksum
+        run: |
+          checksum=$(shasum -ba 256 ${{ steps.build.outputs.asset_path }} | cut -d ' ' -f 1)
+
+          echo "Checksum for ${{ steps.build.outputs.asset_name }}: $checksum"
+          echo -n $checksum > ${{ steps.build.outputs.asset_path }}.sha256
+
+      - name: Upload
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_name: ${{ steps.build.outputs.asset_name }}
+          asset_path: ${{ steps.build.outputs.asset_path }}
+          asset_content_type: application/zip
+
+      - name: Upload checksum
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_name: ${{ steps.build.outputs.asset_name }}.sha256
+          asset_path: ${{ steps.build.outputs.asset_path }}.sha256
+          asset_content_type: text/plain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,10 +104,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Install packages
-        run: |
-          sudo apt-get install python3-pip
-          sudo pip install grip
+      - name: Install mdBook
+        uses: peaceiris/actions-mdbook@v1
 
       - name: Checkout
         uses: actions/checkout@v1
@@ -120,12 +118,13 @@ jobs:
 
       - name: Build
         run: |
-          mkdir -p docs
-          rename.ul '::' '__' ../SDK.wiki/*
-
-          ./.github/workflows/convert-docs.sh ../SDK.wiki ./docs ${{ secrets.GITHUB_TOKEN }}
-
-          zip docs.zip docs/*
+          mkdir -p book/src
+          cp ../SDK.wiki/*.md book/src/
+          rename.ul '::' '__' book/src/*
+          cd book
+          cat src/_Sidebar.md | ./linkfix.py summary > src/SUMMARY.md
+          mdbook build -d docs
+          zip -r ../docs.zip docs/*
 
       - name: Upload
         uses: actions/upload-release-asset@v1.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,9 @@ src/modio.lib
 src/modio.exp
 src/modio.a
 
+# mdBook for release workflow
+book/src
+book/docs
+
 !examples/c/mods_dir/readme.txt
 !examples/c++/mods_dir/readme.txt

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Discord](https://img.shields.io/discord/389039439487434752.svg?label=Discord&logo=discord&color=7289DA&labelColor=2C2F33)](https://discord.mod.io)
 [![Master docs](https://img.shields.io/badge/docs-master-green.svg)](https://github.com/modio/SDK/wiki)
 [![Travis](https://img.shields.io/travis/modio/SDK.svg?logo=travis)](https://travis-ci.org/modio/SDK)
+[![GitHub Action](https://github.com/modio/SDK/workflows/ci/badge.svg)](https://github.com/modio/SDK/actions)
 
 Welcome to the [mod.io SDK](https://apps.mod.io/sdk) repository, built using C and C++. It allows game developers to host and automatically install user-created mods in their games. It connects to the [mod.io API](https://docs.mod.io), and [documentation for its functions](https://github.com/modio/SDK/wiki) can be viewed here.
 

--- a/book/book.toml
+++ b/book/book.toml
@@ -1,0 +1,9 @@
+[book]
+authors = ["Ahmed Castro <ahmed.hn.43@gmail.com>"]
+language = "en"
+multilingual = false
+src = "src"
+title = "modio SDK"
+
+[preprocessor.linkfix]
+command = "./linkfix.py"

--- a/book/linkfix.py
+++ b/book/linkfix.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+import json
+import re
+import sys
+
+"""Match [[File]] and [[Title|File]]"""
+WIKI_LINK = re.compile('(?:\[\[(?:(.*)\|)?(.*)\]\])')
+
+def replace_links(content):
+    def repl(m):
+        (title, filename) = m.group(1, 2)
+
+        title = title if title else filename
+        filename = filename.strip().replace(' ', '-').replace('::', '__')
+
+        return "[%s](%s.md)" % (title.strip(), filename)
+
+    return WIKI_LINK.sub(repl, content)
+
+def walk_book(section, func):
+    if 'Chapter' not in section:
+        return
+
+    content = section['Chapter']['content'];
+    content = func(content)
+    section['Chapter']['content'] = content
+
+    for section in section['Chapter']['sub_items']:
+        walk_book(section, func)
+
+def main():
+    if len(sys.argv) > 1 and sys.argv[1] == 'supports':
+        exit(0)
+
+    if len(sys.argv) > 1 and sys.argv[1] == 'summary':
+        content = sys.stdin.buffer.read().decode('utf-8')
+        """
+        Every chapter must contain a link.
+        Change every `* Foobar` to `* [[Foobar]]`.
+        """
+        content = re.sub('\* ([A-Za-z ]+)', lambda m: "* [[%s]]" % m.group(1), content)
+        print(replace_links(content))
+        exit(0)
+
+    raw = sys.stdin.buffer.read()
+    [context, book] = json.loads(raw.decode('utf-8'))
+
+    for section in book['sections']:
+        walk_book(section, replace_links)
+
+    json.dump(book, sys.stdout)
+    exit(0)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Two workflows for CI and release builds

- The CI workflow builds the sdk with tests for all supported platforms.
- The release workflow builds the sdk in release mode for linux, windows & macOS versions when a GitHub release is published and uploads the sdk.zip & docs.zip to the release.

The upload action does not support overwriting assets and would fail when a docs.zip from re-publishing a release is still there.