### PR TITLE
Run macOS build jobs on macOS-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
           - Ubuntu 18.04 Clang
           - Windows 2019 MSVC
           # - Windows 2019 GCC
-          - macOS 10.14 GCC
-          - macOS 10.14 Clang
+          - macOS 10.15 GCC
+          - macOS 10.15 Clang
         include:
           - name: Ubuntu 16.04 GCC
             os: ubuntu-16.04
@@ -52,13 +52,13 @@ jobs:
           #   cmake-args: -G Ninja
           #   packages: ninja
 
-          - name: macOS 10.14 GCC
-            os: macOS-10.14
+          - name: macOS 10.15 GCC
+            os: macOS-latest
             compiler: gcc
             cpp-compiler: g++
 
-          - name: macOS 10.14 Clang
-            os: macOS-10.14
+          - name: macOS 10.15 Clang
+            os: macOS-latest
             compiler: clang
             cpp-compiler: clang++
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ jobs:
           - Windows 2019 MSVC win32 +static
           - Windows 2019 MSVC win64
           - Windows 2019 MSVC win64 +static
-          - macOS 10.14 Clang
-          - macOS 10.14 Clang +static
+          - macOS 10.15 Clang
+          - macOS 10.15 Clang +static
         include:
           - name: Ubuntu 18.04 GCC+libcurl-gnutls
             os: ubuntu-18.04
@@ -49,12 +49,12 @@ jobs:
             cmake-args: -A x64 -DBUILD_SHARED_LIBS=OFF
             artifact-name: x86_64-windows-msvc+static
 
-          - name: macOS 10.14 Clang
-            os: macOS-10.14
+          - name: macOS 10.15 Clang
+            os: macOS-latest
             artifact-name: x86_64-apple-darwin
 
-          - name: macOS 10.14 Clang +static
-            os: macOS-10.14
+          - name: macOS 10.15 Clang +static
+            os: macOS-latest
             cmake-args: -DBUILD_SHARED_LIBS=OFF
             artifact-name: x86_64-apple-darwin+static
 


### PR DESCRIPTION
> GitHub Actions has deprecated the macOS-10.14 virtual environment. Workflows will instead use macOS-10.15 until January 15th, when workflow files must be updated to continue to run.
> ...
> Please update workflows in those repositories and change the line `runs-on: macOS-10.14` to `runs-on: macOS-latest`. 