### PR TITLE
MOD_DELETED processing in polling

### DIFF
--- a/include/c/ModioC.h
+++ b/include/c/ModioC.h
@@ -52,6 +52,7 @@ typedef int i32;
 #define MODIO_EVENT_USER_TEAM_LEAVE   6
 #define MODIO_EVENT_USER_SUBSCRIBE    7
 #define MODIO_EVENT_USER_UNSUBSCRIBE  8
+#define MODIO_EVENT_MOD_DELETED       9
 
 // Presentation Option Constants
 #define MODIO_GRID_VIEW   0

--- a/include/c/ModioC.h
+++ b/include/c/ModioC.h
@@ -266,7 +266,7 @@ extern "C"
     char* thumb_640x360;
     char* thumb_1280x720;
   };
-  
+
   struct ModioIcon
   {
     char* filename;
@@ -469,7 +469,7 @@ extern "C"
 	  char* path;
 	  ModioMod mod;
   };
-  
+
   struct ModioQueuedModDownload
   {
     u32 state;
@@ -689,8 +689,8 @@ extern "C"
   void MODIO_DLL modioCancelModDownload(u32 mod_id);
   void MODIO_DLL modioResumeDownloads(void);
   void MODIO_DLL modioPrioritizeModDownload(u32 mod_id);
-  void MODIO_DLL modioSetDownloadListener(void (*callback)(u32 response_code, u32 mod_id));  
-  void MODIO_DLL modioSetUploadListener(void (*callback)(u32 response_code, u32 mod_id));  
+  void MODIO_DLL modioSetDownloadListener(void (*callback)(u32 response_code, u32 mod_id));
+  void MODIO_DLL modioSetUploadListener(void (*callback)(u32 response_code, u32 mod_id));
   u32 MODIO_DLL modioGetModDownloadQueueCount(void);
   void MODIO_DLL modioGetModDownloadQueue(ModioQueuedModDownload* download_queue);
   u32 MODIO_DLL modioGetModfileUploadQueueCount(void);
@@ -712,7 +712,7 @@ extern "C"
   //Comment Methods
   void MODIO_DLL modioGetAllModComments(void* object, u32 mod_id, ModioFilterCreator filter, void (*callback)(void* object, ModioResponse response, ModioComment comments[], u32 comments_size));
   void MODIO_DLL modioGetAllModCommentsFilterString(void* object, u32 mod_id, char const* filter_string, u32 cache_max_age_seconds, void (*callback)(void* object, ModioResponse response, ModioComment comments[], u32 comments_size));
-  void MODIO_DLL modioGetModComment(void* object, u32 mod_id, u32 comment_id, void (*callback)(void* object, ModioResponse response, ModioComment comment));  
+  void MODIO_DLL modioGetModComment(void* object, u32 mod_id, u32 comment_id, void (*callback)(void* object, ModioResponse response, ModioComment comment));
   void MODIO_DLL modioDeleteModComment(void* object, u32 mod_id, u32 comment_id, void(*callback)(void* object, ModioResponse response));
 
   //Reports Methods
@@ -728,7 +728,7 @@ extern "C"
   void MODIO_DLL modioFreeQueuedModDownload(ModioQueuedModDownload* queued_mod_download);
   void MODIO_DLL modioFreeQueuedModfileUpload(ModioQueuedModfileUpload* queued_modfile_upload);
 
-  // General Utility Methods 
+  // General Utility Methods
   void MODIO_DLL compressFiles(char const* root_directory, char const* const filenames[], u32 filenames_size, char const* zip_path);
   void MODIO_DLL extractFiles(char const* zip_path, char const* directory_path);
   void MODIO_DLL windowsUTF8ToAnsi(const char* UTF8_string, char* ansi_string);

--- a/src/ModioUtility.cpp
+++ b/src/ModioUtility.cpp
@@ -227,6 +227,7 @@ static void onGetAllEventsPoll(void *object, ModioResponse response, ModioModEve
 
     std::vector<u32> mod_edited_ids;
     std::vector<u32> mod_to_download_queue_ids;
+    std::vector<u32> mod_deleted_ids;
     if(events_array_size > 0)
       modio::clearCache();
     for (size_t i = 0; i < events_array_size; i++)
@@ -316,11 +317,22 @@ static void onGetAllEventsPoll(void *object, ModioResponse response, ModioModEve
         mod_edited_ids.push_back(events_array[i].mod_id);
         break;
       }
+      case MODIO_EVENT_MOD_DELETED:
+      {
+        modio::writeLogLine("Mod deleted. Mod id: " + modio::toString(events_array[i].mod_id) + " Uninstalling...", MODIO_DEBUGLEVEL_LOG);
+        mod_deleted_ids.push_back(events_array[i].mod_id);
+      }
       }
     }
     /* TODO: Re-enable mod profile update? */
     //if (mod_edited_ids.size() > 0)
     //  updateModsCache(mod_edited_ids);
+    size_t deleted_mod_count = mod_deleted_ids.size();
+    for (size_t i = 0; i < deleted_mod_count; ++i)
+    {
+      modioUninstallMod(mod_deleted_ids[i]);
+    }
+
     if (mod_to_download_queue_ids.size() > 0)
       addModsToDownloadQueue(mod_to_download_queue_ids);
 

--- a/src/ModioUtility.cpp
+++ b/src/ModioUtility.cpp
@@ -67,7 +67,7 @@ void onUpdateCurrentUserSubscriptions(void* object, ModioResponse response, Modi
 {
   if(response.result_offset == 0) /* Clear only if is first result page */
     modio::current_user_subscriptions.clear();
-  
+
   if (response.code >= 200 && response.code < 300)
   {
     modio::writeLogLine("Current user subscriptions retrieved sucessfully.", MODIO_DEBUGLEVEL_LOG);
@@ -185,7 +185,7 @@ void updateModsCache(std::vector<u32> mod_ids)
   modioInitFilter(&filter);
 
   std::vector<int>* ptr_mod_ids = new std::vector<int>();
-  
+
   for (auto &mod_id : mod_ids)
   {
     modioAddFilterInField(&filter, "id", modio::toString(mod_id).c_str());
@@ -205,9 +205,9 @@ void addModsToDownloadQueue(std::vector<u32> mod_ids)
   }
   ModioFilterCreator filter;
   modioInitFilter(&filter);
-  
+
   std::vector<int>* ptr_mod_ids = new std::vector<int>();
-  
+
   for (auto &mod_id : mod_ids)
   {
     modioAddFilterInField(&filter, "id", modio::toString(mod_id).c_str());
@@ -236,7 +236,7 @@ static void onGetAllEventsPoll(void *object, ModioResponse response, ModioModEve
         modio::writeLogLine("Mod event id polled: " + modio::toString(events_array[i].id), MODIO_DEBUGLEVEL_LOG);
         modio::LAST_MOD_EVENT_POLL_ID = events_array[i].id;
       }
-      
+
       switch (events_array[i].event_type)
       {
       case MODIO_EVENT_UNDEFINED:
@@ -553,7 +553,7 @@ void handleDownloadImageError(void *object, void (*callback)(void *object, Modio
 void processGenericLocalUnauthorizedRequest(void* object, void(*callback)(void* object, ModioResponse response))
 {
   modio::writeLogLine("Unauthorized local request found. 401 will be returned", MODIO_DEBUGLEVEL_LOG);
-  
+
   ModioResponse response;
   nlohmann::json empty_json;
   modioInitResponse(&response, empty_json);
@@ -575,7 +575,7 @@ void processLocalUnauthorizedRequestModParam(void* object, void (*callback)(void
   modioInitMod(&mod, empty_json);
 
   callback(object, response, mod);
-  
+
   modioFreeResponse(&response);
   modioFreeMod(&mod);
 }
@@ -593,7 +593,7 @@ void processLocalUnauthorizedRequestModfileParam(void* object, void (*callback)(
   modioInitModfile(&modfile, empty_json);
 
   callback(object, response, modfile);
-  
+
   modioFreeResponse(&response);
   modioFreeModfile(&modfile);
 }
@@ -609,7 +609,7 @@ void processLocalUnauthorizedRequestBoolParam(void* object, void (*callback)(voi
   modioInitResponse(&response, empty_json);
 
   callback(object, response, false);
-  
+
   modioFreeResponse(&response);
 }
 
@@ -626,7 +626,7 @@ void processLocalUnauthorizedRequestUserParam(void* object, void (*callback)(voi
   modioInitUser(&user, empty_json);
 
   callback(object, response, user);
-  
+
   modioFreeResponse(&response);
   modioFreeUser(&user);
 }
@@ -642,7 +642,7 @@ void processLocalUnauthorizedRequestModsParam(void* object, void (*callback)(voi
   modioInitResponse(&response, empty_json);
 
   callback(object, response, NULL, 0);
-  
+
   modioFreeResponse(&response);
 }
 
@@ -657,7 +657,7 @@ void processLocalUnauthorizedRequestUserEventsParam(void* object, void (*callbac
   modioInitResponse(&response, empty_json);
 
   callback(object, response, NULL, 0);
-  
+
   modioFreeResponse(&response);
 }
 
@@ -672,7 +672,7 @@ void processLocalUnauthorizedRequestGamesParam(void* object, void (*callback)(vo
   modioInitResponse(&response, empty_json);
 
   callback(object, response, NULL, 0);
-  
+
   modioFreeResponse(&response);
 }
 
@@ -687,7 +687,7 @@ void processLocalUnauthorizedRequestModfilesParam(void* object, void (*callback)
   modioInitResponse(&response, empty_json);
 
   callback(object, response, NULL, 0);
-  
+
   modioFreeResponse(&response);
 }
 
@@ -702,7 +702,7 @@ void processLocalUnauthorizedRequestRatingsParam(void* object, void (*callback)(
   modioInitResponse(&response, empty_json);
 
   callback(object, response, NULL, 0);
-  
+
   modioFreeResponse(&response);
 }
 

--- a/src/c/schemas/ModioModEvent.cpp
+++ b/src/c/schemas/ModioModEvent.cpp
@@ -29,6 +29,8 @@ extern "C"
         event->event_type = MODIO_EVENT_MOD_UNAVAILABLE;
       else if(event_json["event_type"] == "MOD_EDITED")
         event->event_type = MODIO_EVENT_MOD_EDITED;
+      else if(event_json["event_type"] == "MOD_DELETED")
+        event->event_type = MODIO_EVENT_MOD_DELETED;
       else if(event_json["event_type"] == "USER_TEAM_JOIN")
         event->event_type = MODIO_EVENT_USER_TEAM_JOIN;
       else if(event_json["event_type"] == "USER_TEAM_LEAVE")

--- a/src/c/schemas/ModioUserEvent.cpp
+++ b/src/c/schemas/ModioUserEvent.cpp
@@ -33,6 +33,8 @@ extern "C"
         event->event_type = MODIO_EVENT_MOD_UNAVAILABLE;
       else if(event_json["event_type"] == "MOD_EDITED")
         event->event_type = MODIO_EVENT_MOD_EDITED;
+      else if(event_json["event_type"] == "MOD_DELETED")
+        event->event_type = MODIO_EVENT_MOD_DELETED;
       else if(event_json["event_type"] == "USER_TEAM_JOIN")
         event->event_type = MODIO_EVENT_USER_TEAM_JOIN;
       else if(event_json["event_type"] == "USER_TEAM_LEAVE")


### PR DESCRIPTION
Implemented MOD_DELETED event handling in the pollInstalledMods routine.
Mods with the MOD_DELETED event will be uninstalled from the mod collection on the player's system.