### PR TITLE
Event code reduction

### DIFF
--- a/src/ModioUtility.cpp
+++ b/src/ModioUtility.cpp
@@ -269,7 +269,7 @@ static void onGetAllEventsPoll(void *object, ModioResponse response, ModioModEve
       }
       }
     }
-    /* TODO: Re-enable loca mod profile update? */
+    /* TODO: Re-enable mod profile update? */
     //if (mod_edited_ids.size() > 0)
     //  updateModsCache(mod_edited_ids);
     if (mod_to_download_queue_ids.size() > 0)

--- a/src/ModioUtility.cpp
+++ b/src/ModioUtility.cpp
@@ -244,62 +244,11 @@ static void onGetAllEventsPoll(void *object, ModioResponse response, ModioModEve
         break;
       case MODIO_EVENT_MODFILE_CHANGED:
       {
-        bool reinstall = true;
-        for (auto installed_mod : modio::installed_mods)
-        {
-          if (modio::hasKey(installed_mod, "mod_id") &&
-              modio::hasKey(installed_mod, "date_updated") &&
-              installed_mod["mod_id"] == events_array[i].mod_id &&
-              installed_mod["date_updated"] >= events_array[i].date_added)
-          {
-            reinstall = false;
-            modio::writeLogLine("Modfile changed event detected but you already have a newer version installed, the modfile will not be downloaded. Mod id: " + modio::toString(events_array[i].mod_id), MODIO_DEBUGLEVEL_LOG);
-          }
-        }
-
-        for (auto &downloaded_mod_json : modio::g_downloaded_mods)
-        {
-          if (modio::hasKey(downloaded_mod_json, "mod") &&
-              modio::hasKey(downloaded_mod_json["mod"], "id") &&
-              downloaded_mod_json["mod"]["id"] == events_array[i].mod_id)
-          {
-            if (modio::hasKey(downloaded_mod_json["mod"], "date_updated") &&
-                downloaded_mod_json["mod"]["date_updated"] >= events_array[i].date_added)
-            {
-              reinstall = false;
-              modio::writeLogLine("Modfile changed event detected but you already have a newer version downloaded, the modfile will not be downloaded. Mod id: " + modio::toString(events_array[i].mod_id), MODIO_DEBUGLEVEL_LOG);
-            }else
-            {
-              nlohmann::json downloaded_mods_json_temp;
-              for (auto &downloaded_mod_temp_json : modio::g_downloaded_mods)
-              {
-                if(modio::hasKey(downloaded_mod_temp_json, "mod") &&
-                    modio::hasKey(downloaded_mod_temp_json["mod"], "id") &&
-                    downloaded_mod_temp_json["mod"]["id"] != events_array[i].mod_id)
-                {
-                  downloaded_mods_json_temp.push_back(downloaded_mod_temp_json);
-                }
-              }
-              modio::g_downloaded_mods = downloaded_mods_json_temp;
-
-              if(modio::hasKey(downloaded_mod_json, "downloaded_zip_path"))
-              {
-                std::string downloaded_zip_path = downloaded_mod_json["downloaded_zip_path"];
-                modio::removeFile(downloaded_zip_path);
-              }
-              modio::writeLogLine("Modfile changed event detected and you have an older version downloaded, old modfile will be deleted. Mod id: " + modio::toString(events_array[i].mod_id), MODIO_DEBUGLEVEL_LOG);
-              break;
-            }
-          }
-        }
-
-        if (reinstall)
-        {
-          modio::writeLogLine("Modfile changed. Mod id: " + modio::toString(events_array[i].mod_id) + " Reisntalling...", MODIO_DEBUGLEVEL_LOG);
-          mod_to_download_queue_ids.push_back(events_array[i].mod_id);
-        }
+        modio::writeLogLine("Modfile changed. Mod id: " + modio::toString(events_array[i].mod_id), MODIO_DEBUGLEVEL_LOG);
+        modio::writeLogLine(" Adding to the download queue...", MODIO_DEBUGLEVEL_LOG);
+        mod_to_download_queue_ids.push_back(events_array[i].mod_id);
+        break;
       }
-      break;
       case MODIO_EVENT_MOD_AVAILABLE:
       {
         // N/A
@@ -312,13 +261,15 @@ static void onGetAllEventsPoll(void *object, ModioResponse response, ModioModEve
       }
       case MODIO_EVENT_MOD_EDITED:
       {
-        modio::writeLogLine("Mod updated. Mod id: " + modio::toString(events_array[i].mod_id) + " Updating cache...", MODIO_DEBUGLEVEL_LOG);
-        mod_edited_ids.push_back(events_array[i].mod_id);
+        modio::writeLogLine("Mod edited. Mod id: " + modio::toString(events_array[i].mod_id), MODIO_DEBUGLEVEL_LOG);
+        /* TODO: Re-enable local mod profile update? */
+        //modio::writeLogLine("Mod updated. Mod id: " + modio::toString(events_array[i].mod_id) + " Updating cache...", MODIO_DEBUGLEVEL_LOG);
+        //mod_edited_ids.push_back(events_array[i].mod_id);
         break;
       }
       }
     }
-    /* TODO: Re-enable mod profile update? */
+    /* TODO: Re-enable loca mod profile update? */
     //if (mod_edited_ids.size() > 0)
     //  updateModsCache(mod_edited_ids);
     if (mod_to_download_queue_ids.size() > 0)


### PR DESCRIPTION
Now all redownload prevention checks are done after the `Get All Mods` request down after polling.