### PR TITLE
Handle 416

### DIFF
--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -3,7 +3,7 @@
 
 namespace modio
 {
-  std::string VERSION = "v0.12.14 DEV";
+  std::string VERSION = "v0.12.15 DEV";
   std::string API_KEY;
   std::string ACCESS_TOKEN = "";
   u32 GAME_ID;

--- a/src/wrappers/CurlCallbacks.cpp
+++ b/src/wrappers/CurlCallbacks.cpp
@@ -112,6 +112,12 @@ void onModDownloadFinished(CURL *curl)
       writeLogLine("Response code: " + modio::toString(response_code) + " Mod id: " + modio::toString(g_current_mod_download->queued_mod_download->mod_id), MODIO_DEBUGLEVEL_ERROR);
     }
 
+    if (response_code >= 416)
+    {
+      writeLogLine("API returned 416, uninstalling mod id: " + toString(g_current_mod_download->queued_mod_download->mod.id), MODIO_DEBUGLEVEL_ERROR);
+      modioUninstallMod(g_current_mod_download->queued_mod_download->mod.id);
+    }
+
     if (modio::download_callback)
     {
       modio::download_callback(response_code,  g_current_mod_download->queued_mod_download->mod.id);


### PR DESCRIPTION
When API returns `416` on a download request, the local modfile progress will be removed.