### PR TITLE
Bugfix reinit sdk cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@
 # Visual Studio
 .vs/
 .vscode/
+CMakeSettings.json
 
 # KDevelop
 .kdev4/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,3 +141,17 @@ if( INCLUDE_EXAMPLES )
     ENDIF()
   ENDIF()
 endif()
+
+if(BUILD_SHARED_LIBS)
+    set(PREFIX ${CMAKE_SHARED_MODULE_PREFIX})
+    set(POSTFIX ${CMAKE_SHARED_LIBRARY_SUFFIX})
+else()
+    set(PREFIX ${CMAKE_STATIC_LIBRARY_PREFIX})
+    set(POSTFIX ${CMAKE_STATIC_LIBRARY_SUFFIX})
+endif()
+
+# Set properties let projects that use this project as a subdirectory know how to play along with it
+set_target_properties(modio
+    PROPERTIES 
+    OUTPUT_NAME "${PREFIX}modio"
+    SUFFIX "${POSTFIX}")

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Master docs](https://img.shields.io/badge/docs-master-green.svg)](https://github.com/modio/SDK/wiki)
 [![GitHub Action](https://github.com/modio/SDK/workflows/ci/badge.svg)](https://github.com/modio/SDK/actions)
 
-Welcome to the [mod.io SDK](https://apps.mod.io/sdk) repository, built using C and C++. It allows game developers to host and automatically install user-created mods in their games. It connects to the [mod.io API](https://docs.mod.io), and [documentation for its functions](https://github.com/modio/SDK/wiki) can be viewed here.
+Welcome to the mod.io SDK repository, built using C and C++. It allows game developers to host and automatically install user-created mods in their games. It connects to the [mod.io API](https://docs.mod.io), and [documentation for its functions](https://github.com/modio/SDK/wiki) can be viewed here.
 
 ## Features
 

--- a/src/modio.cpp
+++ b/src/modio.cpp
@@ -121,8 +121,7 @@ void modioInit(u32 environment, u32 game_id, bool retrieve_mods_from_other_games
   modio::RETRIEVE_MODS_FROM_OTHER_GAMES = retrieve_mods_from_other_games;
   modio::POLLING_ENABLED = polling_enabled;
   
-  if (root_path)
-    modio::ROOT_PATH = root_path;
+  modio::ROOT_PATH = root_path ? root_path : "";
   
   std::clog << "[mod.io] Creating directories" << std::endl;
 
@@ -152,12 +151,12 @@ void modioInit(u32 environment, u32 game_id, bool retrieve_mods_from_other_games
   
   modio::writeLogLine(modio::VERSION, MODIO_DEBUGLEVEL_LOG);
 
-  if (environment == MODIO_ENVIRONMENT_TEST)
-    modio::MODIO_URL = "https://api.test.mod.io/";
+  modio::MODIO_URL = environment == MODIO_ENVIRONMENT_LIVE ? "https://api.mod.io/" : "https://api.test.mod.io/";
   modio::GAME_ID = game_id;
-  modio::API_KEY = api_key;
+  modio::API_KEY = api_key ? api_key : "";
 
   loadEventPollingFile();
+  // This calls potentially setup modio::ACCESS_TOKEN from cached authentication data, so it has to be called before accessing that token
   loadAuthenticationFile();
 
   modio::curlwrapper::initCurl();


### PR DESCRIPTION
Fixed issues when initializing the SDK after it's shutdown in the same process that all paths/variables are correctly setup again